### PR TITLE
Allow to override transaction options

### DIFF
--- a/packages/safe-core-sdk/README.md
+++ b/packages/safe-core-sdk/README.md
@@ -436,6 +436,16 @@ const txResponse = await safeSdk.executeTransaction(safeTransaction)
 await txResponse.wait()
 ```
 
+Optionally, `gasLimit` and `gasPrice` values can be passed as execution options, avoiding the gas estimation.
+
+```
+const options: ExecuteTransactionOptions = {
+  gasLimit: 123456,
+  gasPrice: 123 // Optional parameter.
+}
+const txResponse = await safeSdk.executeTransaction(safeTransaction, options)
+```
+
 ## License
 
 This library is released under MIT.

--- a/packages/safe-core-sdk/src/EthersSafe.ts
+++ b/packages/safe-core-sdk/src/EthersSafe.ts
@@ -1,5 +1,10 @@
 import { Provider } from '@ethersproject/providers'
-import { OperationType, SafeSignature, SafeTransaction, SafeTransactionDataPartial } from '@gnosis.pm/safe-core-sdk-types'
+import {
+  OperationType,
+  SafeSignature,
+  SafeTransaction,
+  SafeTransactionDataPartial
+} from '@gnosis.pm/safe-core-sdk-types'
 import { BigNumber, ContractTransaction, Signer } from 'ethers'
 import ContractManager from './managers/contractManager'
 import ModuleManager from './managers/moduleManager'
@@ -486,7 +491,10 @@ class EthersSafe implements Safe {
    * @throws "No signer provided"
    * @throws "There are X signatures missing"
    */
-  async executeTransaction(safeTransaction: SafeTransaction, options?: ExecuteTransactionOptions): Promise<ContractTransaction> {
+  async executeTransaction(
+    safeTransaction: SafeTransaction,
+    options?: ExecuteTransactionOptions
+  ): Promise<ContractTransaction> {
     if (!this.#signer) {
       throw new Error('No signer provided')
     }
@@ -512,11 +520,13 @@ class EthersSafe implements Safe {
       )
     }
 
-    const gasLimit = options?.gasLimit || await estimateGasForTransactionExecution(
-      this.#contractManager.safeContract,
-      await this.#signer.getAddress(),
-      safeTransaction
-    )
+    const gasLimit =
+      options?.gasLimit ||
+      (await estimateGasForTransactionExecution(
+        this.#contractManager.safeContract,
+        await this.#signer.getAddress(),
+        safeTransaction
+      ))
     const executionOptions: ExecuteTransactionOptions = {
       gasLimit,
       gasPrice: options?.gasPrice

--- a/packages/safe-core-sdk/src/Safe.ts
+++ b/packages/safe-core-sdk/src/Safe.ts
@@ -1,5 +1,9 @@
 import { Provider } from '@ethersproject/providers'
-import { SafeSignature, SafeTransaction, SafeTransactionDataPartial } from '@gnosis.pm/safe-core-sdk-types'
+import {
+  SafeSignature,
+  SafeTransaction,
+  SafeTransactionDataPartial
+} from '@gnosis.pm/safe-core-sdk-types'
 import { BigNumber, ContractTransaction, Signer } from 'ethers'
 import { ContractNetworksConfig } from './configuration/contracts'
 
@@ -58,7 +62,10 @@ interface Safe {
   getRemoveOwnerTx(ownerAddress: string, threshold?: number): Promise<SafeTransaction>
   getSwapOwnerTx(oldOwnerAddress: string, newOwnerAddress: string): Promise<SafeTransaction>
   getChangeThresholdTx(threshold: number): Promise<SafeTransaction>
-  executeTransaction(safeTransaction: SafeTransaction, options?: ExecuteTransactionOptions): Promise<ContractTransaction>
+  executeTransaction(
+    safeTransaction: SafeTransaction,
+    options?: ExecuteTransactionOptions
+  ): Promise<ContractTransaction>
 }
 
 export default Safe

--- a/packages/safe-core-sdk/src/Safe.ts
+++ b/packages/safe-core-sdk/src/Safe.ts
@@ -23,6 +23,13 @@ export interface ConnectEthersSafeConfig {
   contractNetworks?: ContractNetworksConfig
 }
 
+export interface ExecuteTransactionOptions {
+  /** gasLimit - Safe transaction gas limit */
+  gasLimit: number
+  /** gasPrice - Safe transaction gas price */
+  gasPrice?: number
+}
+
 interface Safe {
   connect({ providerOrSigner, safeAddress, contractNetworks }: ConnectEthersSafeConfig): void
   getProvider(): Provider
@@ -51,7 +58,7 @@ interface Safe {
   getRemoveOwnerTx(ownerAddress: string, threshold?: number): Promise<SafeTransaction>
   getSwapOwnerTx(oldOwnerAddress: string, newOwnerAddress: string): Promise<SafeTransaction>
   getChangeThresholdTx(threshold: number): Promise<SafeTransaction>
-  executeTransaction(safeTransaction: SafeTransaction): Promise<ContractTransaction>
+  executeTransaction(safeTransaction: SafeTransaction, options?: ExecuteTransactionOptions): Promise<ContractTransaction>
 }
 
 export default Safe

--- a/packages/safe-core-sdk/src/index.ts
+++ b/packages/safe-core-sdk/src/index.ts
@@ -1,11 +1,12 @@
 import { ContractNetworksConfig } from './configuration/contracts'
 import EthersSafe from './EthersSafe'
-import Safe, { ConnectEthersSafeConfig, EthersSafeConfig } from './Safe'
+import Safe, { ConnectEthersSafeConfig, EthersSafeConfig, ExecuteTransactionOptions } from './Safe'
 
 export default EthersSafe
 export {
   Safe,
   EthersSafeConfig,
   ConnectEthersSafeConfig,
-  ContractNetworksConfig
+  ContractNetworksConfig,
+  ExecuteTransactionOptions
 }

--- a/packages/safe-core-sdk/tests/execution.test.ts
+++ b/packages/safe-core-sdk/tests/execution.test.ts
@@ -245,7 +245,7 @@ describe('Transactions execution', () => {
         .expect(safeInitialBalance.toString())
         .to.be.eq(safeFinalBalance.add(BigNumber.from(tx.data.value).toString()))
     })
-  
+
     it('should execute a transaction with options: { gasLimit }', async () => {
       const { accounts, contractNetworks } = await setupTests()
       const [account1, account2] = accounts
@@ -270,7 +270,7 @@ describe('Transactions execution', () => {
       await txResponse.wait()
       chai.expect(execOptions.gasLimit).to.be.eq(txResponse.gasLimit.toNumber())
     })
-  
+
     it('should execute a transaction with options: { gasLimit, gasPrice }', async () => {
       const { accounts, contractNetworks } = await setupTests()
       const [account1, account2] = accounts


### PR DESCRIPTION
Adds an `options` parameter to `executeTransaction()` in order to override the `gasLimit` or set a `gasPrice`.

See https://github.com/gnosis/safe-core-sdk/issues/43