### PR TITLE
Use correct endpoint for getSafesByOwner

### DIFF
--- a/packages/safe-service-client/src/SafeServiceClient.ts
+++ b/packages/safe-service-client/src/SafeServiceClient.ts
@@ -82,7 +82,7 @@ class SafeServiceClient implements SafeTransactionService {
    */
   async getSafesByOwner(ownerAddress: string): Promise<OwnerResponse> {
     return sendRequest({
-      url: `${this.#txServiceBaseUrl}/owners/${ownerAddress}/`,
+      url: `${this.#txServiceBaseUrl}/owners/${ownerAddress}/safes/`,
       method: HttpMethod.Get
     })
   }

--- a/packages/safe-service-client/tests/index.test.ts
+++ b/packages/safe-service-client/tests/index.test.ts
@@ -51,7 +51,7 @@ describe('Safe Service Client', () => {
         .to.be.eventually.deep.equals({ success: true })
       chai
         .expect(axiosGet)
-        .to.have.been.calledWith(`${getTxServiceBaseUrl(txServiceBaseUrl)}/owners/${ownerAddress}/`)
+        .to.have.been.calledWith(`${getTxServiceBaseUrl(txServiceBaseUrl)}/owners/${ownerAddress}/safes/`)
     })
 
     it('getTransaction', async () => {


### PR DESCRIPTION
https://safe-transaction.rinkeby.gnosis.io/api/v1/owners/0xA66A5686D5c3A42C0b6c76FEd05e58C6bc851E9f -> 404
https://safe-transaction.rinkeby.gnosis.io/api/v1/owners/0xA66A5686D5c3A42C0b6c76FEd05e58C6bc851E9f/safes/ -> 200

https://safe-transaction.gnosis.io/api/v1/owners/0xA66A5686D5c3A42C0b6c76FEd05e58C6bc851E9f -> 404
https://safe-transaction.gnosis.io/api/v1/owners/0xA66A5686D5c3A42C0b6c76FEd05e58C6bc851E9f/safes/ -> 200