### PR TITLE
Make signatures nullable in SafeMultisigTransactionResponse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,5 @@ deployments
 
 # Typechain
 typechain
+
+openapi/

--- a/packages/safe-service-client/scripts/generateTxServiceTypes.sh
+++ b/packages/safe-service-client/scripts/generateTxServiceTypes.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+mkdir -p openapi
+curl 'https://safe-transaction.rinkeby.gnosis.io/?format=openapi' > openapi/tx-service.json
+npx openapi-typescript openapi/tx-service.json --output openapi/tx-service.ts

--- a/packages/safe-service-client/src/types/safeTransactionServiceTypes.ts
+++ b/packages/safe-service-client/src/types/safeTransactionServiceTypes.ts
@@ -134,7 +134,7 @@ export type SafeMultisigTransactionResponse = {
   readonly dataDecoded?: string
   readonly confirmationsRequired: number
   readonly confirmations?: SafeMultisigConfirmationResponse[]
-  readonly signatures: string
+  readonly signatures?: string
 }
 
 export type SafeMultisigTransactionListResponse = {


### PR DESCRIPTION
Makes the property `signatures` nullable in the type `SafeMultisigTransactionResponse` returned by the Safe Transaction Service.