### PR TITLE
Add a PR template and typedoc site generation

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,4 @@
+## What it solves
+Resolves #
+
+## How this PR fixes it

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -20,6 +20,6 @@ jobs:
           path-to-signatures: 'signatures/version1/cla.json'
           path-to-cla-document: 'https://gnosis-safe.io/cla/'
           branch: 'cla-signatures'
-          allowlist: germartinez,mikheevm,rmeissner,Uxio0,dasanra,davidalbela,luarx,giacomolicari,lukasschor,tschubotz,gnosis-info,bot*
+          allowlist: germartinez,mikheevm,rmeissner,Uxio0,dasanra,davidalbela,luarx,giacomolicari,lukasschor,tschubotz,gnosis-info,bot*,katspaugh
           empty-commit-flag: false
           blockchain-storage-flag: false

--- a/.github/workflows/typedoc.yml
+++ b/.github/workflows/typedoc.yml
@@ -1,0 +1,31 @@
+name: typedoc
+
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  typedoc:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+
+      - run: npm install
+
+      - run: npm run build
+
+      - run: npm install typescript typedoc
+
+      - name: Create the docs directory locally in CI
+        run: ./node_modules/.bin/typedoc --tsconfig packages/safe-core-sdk/tsconfig.json packages/safe-core-sdk/src
+
+      - name: Deploy 🚀
+        uses: JamesIves/github-pages-deploy-action@4.1.4
+        with:
+          branch: gh-pages
+          folder: docs


### PR DESCRIPTION
This PR adds a PR template to make linking PRs to issues easier.

It also introduces a github action that generates HTML docs based on types and deploys them to GitHub Pages.
Once this is merged, GitHub Pages need to be enabled.

## Docs screenshot
<img width="777" alt="Screenshot 2021-10-05 at 13 07 19" src="https://user-images.githubusercontent.com/381895/136011867-85f7432f-3275-468f-a396-39d5eb55e450.png">

## How to enable GitHub pages
<img width="1029" alt="Screenshot 2021-10-05 at 13 09 15" src="https://user-images.githubusercontent.com/381895/136011975-423cc6c6-a862-4909-addb-dc814fd954d9.png">

