### PR TITLE
Handle delegates

### DIFF
--- a/packages/safe-service-client/README.md
+++ b/packages/safe-service-client/README.md
@@ -115,6 +115,14 @@ Adds a new delegate for a given Safe address. The signature is calculated by sig
 await safeService.addSafeDelegate(safeAddress, delegate)
 ```
 
+### removeAllSafeDelegates
+
+Removes all delegates for a given Safe address. The signature is calculated by signing this hash: `keccak(address + str(int(current_epoch / 3600)))`.
+
+```js
+await safeService.removeAllSafeDelegates(safeAddress)
+```
+
 ### removeSafeDelegate
 
 Removes a delegate for a given Safe address. The signature is calculated by signing this hash: `keccak(address + str(int(current_epoch / 3600)))`.

--- a/packages/safe-service-client/e2e/addSafeDelegate.test.ts
+++ b/packages/safe-service-client/e2e/addSafeDelegate.test.ts
@@ -1,0 +1,154 @@
+import { getDefaultProvider } from '@ethersproject/providers'
+import { Wallet } from '@ethersproject/wallet'
+import chai from 'chai'
+import chaiAsPromised from 'chai-as-promised'
+import SafeServiceClient, { SafeDelegate, SafeDelegateConfig } from '../src'
+import config from './config'
+chai.use(chaiAsPromised)
+
+describe('addSafeDelegate', () => {
+  const serviceSdk = new SafeServiceClient(config.BASE_URL)
+
+  it('should fail if Safe address is empty', async () => {
+    const safeAddress = ''
+    const delegateAddress = '0xFFcf8FDEE72ac11b5c542428B35EEF5769C409f0'
+    const provider = getDefaultProvider(config.JSON_RPC)
+    const signer = new Wallet(
+      '0x4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d', // A Safe owner
+      provider
+    )
+    const delegateConfig: SafeDelegateConfig = {
+      safe: safeAddress,
+      delegate: delegateAddress,
+      signer,
+      label: 'Label'
+    }
+    await chai
+      .expect(serviceSdk.addSafeDelegate(delegateConfig))
+      .to.be.rejectedWith('Invalid Safe address')
+  })
+
+  it('should fail if Safe delegate address is empty', async () => {
+    const safeAddress = '0xf9A2FAa4E3b140ad42AAE8Cac4958cFf38Ab08fD'
+    const delegateAddress = ''
+    const provider = getDefaultProvider(config.JSON_RPC)
+    const signer = new Wallet(
+      '0x4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d', // A Safe owner
+      provider
+    )
+    const delegateConfig: SafeDelegateConfig = {
+      safe: safeAddress,
+      delegate: delegateAddress,
+      signer,
+      label: 'Label'
+    }
+    await chai
+      .expect(serviceSdk.addSafeDelegate(delegateConfig))
+      .to.be.rejectedWith('Invalid Safe delegate address')
+  })
+
+  it('should fail if Safe address is not checksummed', async () => {
+    const safeAddress = '0xf9A2FAa4E3b140ad42AAE8Cac4958cFf38Ab08fD'.toLowerCase()
+    const delegateAddress = '0xFFcf8FDEE72ac11b5c542428B35EEF5769C409f0'
+    const provider = getDefaultProvider(config.JSON_RPC)
+    const signer = new Wallet(
+      '0x4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d', // A Safe owner
+      provider
+    )
+    const delegateConfig: SafeDelegateConfig = {
+      safe: safeAddress,
+      delegate: delegateAddress,
+      signer,
+      label: 'Label'
+    }
+    await chai
+      .expect(serviceSdk.addSafeDelegate(delegateConfig))
+      .to.be.rejectedWith('Checksum address validation failed')
+  })
+
+  it('should fail if Safe delegate address is not checksummed', async () => {
+    const safeAddress = '0xf9A2FAa4E3b140ad42AAE8Cac4958cFf38Ab08fD'
+    const delegateAddress = '0xFFcf8FDEE72ac11b5c542428B35EEF5769C409f0'.toLowerCase()
+    const provider = getDefaultProvider(config.JSON_RPC)
+    const signer = new Wallet(
+      '0x4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d', // A Safe owner
+      provider
+    )
+    const delegateConfig: SafeDelegateConfig = {
+      safe: safeAddress,
+      delegate: delegateAddress,
+      signer,
+      label: 'Label'
+    }
+    await chai
+      .expect(serviceSdk.addSafeDelegate(delegateConfig))
+      .to.be.rejectedWith(`Address ${delegateAddress} is not checksumed`)
+  })
+
+  it('should fail if Safe does not exist', async () => {
+    const safeAddress = '0x1dF62f291b2E969fB0849d99D9Ce41e2F137006e'
+    const delegateAddress = '0xFFcf8FDEE72ac11b5c542428B35EEF5769C409f0'
+    const provider = getDefaultProvider(config.JSON_RPC)
+    const signer = new Wallet(
+      '0x4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d', // A Safe owner
+      provider
+    )
+    const delegateConfig: SafeDelegateConfig = {
+      safe: safeAddress,
+      delegate: delegateAddress,
+      signer,
+      label: 'Label'
+    }
+    await chai
+      .expect(serviceSdk.addSafeDelegate(delegateConfig))
+      .to.be.rejectedWith(`Safe=${safeAddress} does not exist or it's still not indexed`)
+  })
+
+  it('should fail if the signer is not an owner of the Safe', async () => {
+    const safeAddress = '0xf9A2FAa4E3b140ad42AAE8Cac4958cFf38Ab08fD'
+    const delegateAddress = '0xFFcf8FDEE72ac11b5c542428B35EEF5769C409f0'
+    const provider = getDefaultProvider(config.JSON_RPC)
+    const signer = new Wallet(
+      '0xb0057716d5917badaf911b193b12b910811c1497b5bada8d7711f758981c3773', // Not a Safe owner
+      provider
+    )
+    const delegateConfig: SafeDelegateConfig = {
+      safe: safeAddress,
+      delegate: delegateAddress,
+      signer,
+      label: 'Label'
+    }
+    await chai
+      .expect(serviceSdk.addSafeDelegate(delegateConfig))
+      .to.be.rejectedWith('Signing owner is not an owner of the Safe')
+  })
+
+  it('should add a new delegate', async () => {
+    const safeAddress = '0xf9A2FAa4E3b140ad42AAE8Cac4958cFf38Ab08fD'
+    const delegateAddress = '0xFFcf8FDEE72ac11b5c542428B35EEF5769C409f0'
+    const provider = getDefaultProvider(config.JSON_RPC)
+    const signer = new Wallet(
+      '0x4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d', // A Safe owner
+      provider
+    )
+    const delegateConfig: SafeDelegateConfig = {
+      safe: safeAddress,
+      delegate: delegateAddress,
+      signer,
+      label: 'Label'
+    }
+
+    const { results: initialDelegates } = await serviceSdk.getSafeDelegates(safeAddress)
+    chai.expect(initialDelegates.length).to.be.eq(0)
+
+    const delegateResponse: SafeDelegate = await serviceSdk.addSafeDelegate(delegateConfig)
+    chai.expect(delegateResponse.safe).to.be.equal(delegateConfig.safe)
+    chai.expect(delegateResponse.delegate).to.be.equal(delegateConfig.delegate)
+    chai.expect(delegateResponse.signature).to.be.a('string')
+    chai.expect(delegateResponse.label).to.be.equal(delegateConfig.label)
+
+    const { results: finalDelegates } = await serviceSdk.getSafeDelegates(safeAddress)
+    chai.expect(finalDelegates.length).to.be.eq(1)
+    await serviceSdk.removeSafeDelegate(delegateConfig)
+  })
+})

--- a/packages/safe-service-client/e2e/config.ts
+++ b/packages/safe-service-client/e2e/config.ts
@@ -1,5 +1,6 @@
 const config = {
-  baseUrl: 'https://safe-transaction.rinkeby.staging.gnosisdev.com'
+  BASE_URL: 'https://safe-transaction.staging.gnosisdev.com',
+  JSON_RPC: `https://rinkeby.infura.io/v3/${process.env.INFURA_KEY}`
 }
 
 export default config

--- a/packages/safe-service-client/e2e/decodeData.test.ts
+++ b/packages/safe-service-client/e2e/decodeData.test.ts
@@ -6,7 +6,7 @@ import config from './config'
 chai.use(chaiAsPromised)
 
 describe('decodeData', () => {
-  const serviceSdk = new SafeServiceClient(config.baseUrl)
+  const serviceSdk = new SafeServiceClient(config.BASE_URL)
 
   it('should fail if data is empty', async () => {
     const data = ''

--- a/packages/safe-service-client/e2e/getBalances.test.ts
+++ b/packages/safe-service-client/e2e/getBalances.test.ts
@@ -6,7 +6,7 @@ import config from './config'
 chai.use(chaiAsPromised)
 
 describe('getBalances', () => {
-  const serviceSdk = new SafeServiceClient(config.baseUrl)
+  const serviceSdk = new SafeServiceClient(config.BASE_URL)
 
   it('should fail if Safe address is empty', async () => {
     const safeAddress = ''

--- a/packages/safe-service-client/e2e/getCollectibles.test.ts
+++ b/packages/safe-service-client/e2e/getCollectibles.test.ts
@@ -6,7 +6,7 @@ import config from './config'
 chai.use(chaiAsPromised)
 
 describe('getCollectibles', () => {
-  const serviceSdk = new SafeServiceClient(config.baseUrl)
+  const serviceSdk = new SafeServiceClient(config.BASE_URL)
 
   it('should fail if Safe address is empty', async () => {
     const safeAddress = ''

--- a/packages/safe-service-client/e2e/getIncomingTransactions.test.ts
+++ b/packages/safe-service-client/e2e/getIncomingTransactions.test.ts
@@ -6,7 +6,7 @@ import config from './config'
 chai.use(chaiAsPromised)
 
 describe('getIncomingTransactions', () => {
-  const serviceSdk = new SafeServiceClient(config.baseUrl)
+  const serviceSdk = new SafeServiceClient(config.BASE_URL)
 
   it('should fail if Safe address is empty', async () => {
     const safeAddress = ''

--- a/packages/safe-service-client/e2e/getMultisigTransactions.test.ts
+++ b/packages/safe-service-client/e2e/getMultisigTransactions.test.ts
@@ -9,7 +9,7 @@ import config from './config'
 chai.use(chaiAsPromised)
 
 describe('getMultisigTransactions', () => {
-  const serviceSdk = new SafeServiceClient(config.baseUrl)
+  const serviceSdk = new SafeServiceClient(config.BASE_URL)
 
   it('should fail if Safe address is empty', async () => {
     const safeAddress = ''

--- a/packages/safe-service-client/e2e/getPendingTransactions.test.ts
+++ b/packages/safe-service-client/e2e/getPendingTransactions.test.ts
@@ -6,7 +6,7 @@ import config from './config'
 chai.use(chaiAsPromised)
 
 describe('getPendingTransactions', () => {
-  const serviceSdk = new SafeServiceClient(config.baseUrl)
+  const serviceSdk = new SafeServiceClient(config.BASE_URL)
 
   it('should fail if safeAddress is empty', async () => {
     const safeAddress = ''

--- a/packages/safe-service-client/e2e/getSafeDelegates.test.ts
+++ b/packages/safe-service-client/e2e/getSafeDelegates.test.ts
@@ -1,0 +1,77 @@
+import { getDefaultProvider } from '@ethersproject/providers'
+import { Wallet } from '@ethersproject/wallet'
+import chai from 'chai'
+import chaiAsPromised from 'chai-as-promised'
+import SafeServiceClient, {
+  SafeDelegateConfig,
+  SafeDelegateListResponse,
+  SafeDelegateResponse
+} from '../src'
+import config from './config'
+
+chai.use(chaiAsPromised)
+
+describe('getSafeDelegates', () => {
+  const serviceSdk = new SafeServiceClient(config.BASE_URL)
+
+  it('should fail if Safe address is empty', async () => {
+    const safeAddress = ''
+    await chai
+      .expect(serviceSdk.getSafeDelegates(safeAddress))
+      .to.be.rejectedWith('Invalid Safe address')
+  })
+
+  it('should fail if Safe address is not checksummed', async () => {
+    const safeAddress = '0xf9A2FAa4E3b140ad42AAE8Cac4958cFf38Ab08fD'.toLowerCase()
+    await chai
+      .expect(serviceSdk.getSafeDelegates(safeAddress))
+      .to.be.rejectedWith('Checksum address validation failed')
+  })
+
+  it('should return an empty array if the Safe address is not found', async () => {
+    const safeAddress = '0x11dBF28A2B46bdD4E284e79e28B2E8b94Cfa39Bc'
+    const safeDelegateListResponse: SafeDelegateListResponse = await serviceSdk.getSafeDelegates(
+      safeAddress
+    )
+    const results: SafeDelegateResponse[] = safeDelegateListResponse.results
+    chai.expect(results).to.be.empty
+  })
+
+  it('should return an array of delegates', async () => {
+    const safeAddress = '0xf9A2FAa4E3b140ad42AAE8Cac4958cFf38Ab08fD'
+    const provider = getDefaultProvider(config.JSON_RPC)
+    const signer = new Wallet(
+      '0x4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d', // A Safe owner
+      provider
+    )
+
+    const delegateConfig1: SafeDelegateConfig = {
+      safe: safeAddress,
+      delegate: '0xFFcf8FDEE72ac11b5c542428B35EEF5769C409f0',
+      signer,
+      label: 'Label1'
+    }
+    const delegateConfig2: SafeDelegateConfig = {
+      safe: safeAddress,
+      delegate: '0x22d491Bde2303f2f43325b2108D26f1eAbA1e32b',
+      signer,
+      label: 'Label2'
+    }
+    await serviceSdk.addSafeDelegate(delegateConfig1)
+    await serviceSdk.addSafeDelegate(delegateConfig2)
+
+    const safeDelegateListResponse: SafeDelegateListResponse = await serviceSdk.getSafeDelegates(
+      safeAddress
+    )
+    const { results } = safeDelegateListResponse
+    chai.expect(results.length).to.be.eq(2)
+    chai.expect(results[0].delegate).to.be.eq(delegateConfig1.delegate)
+    chai.expect(results[0].delegator).to.be.eq(await delegateConfig1.signer.getAddress())
+    chai.expect(results[0].label).to.be.eq(delegateConfig1.label)
+    chai.expect(results[1].delegate).to.be.eq(delegateConfig2.delegate)
+    chai.expect(results[1].delegator).to.be.eq(await delegateConfig2.signer.getAddress())
+    chai.expect(results[1].label).to.be.eq(delegateConfig2.label)
+
+    await serviceSdk.removeAllSafeDelegates(safeAddress, signer)
+  })
+})

--- a/packages/safe-service-client/e2e/getSafeInfo.test.ts
+++ b/packages/safe-service-client/e2e/getSafeInfo.test.ts
@@ -6,7 +6,7 @@ import config from './config'
 chai.use(chaiAsPromised)
 
 describe('getSafeInfo', () => {
-  const serviceSdk = new SafeServiceClient(config.baseUrl)
+  const serviceSdk = new SafeServiceClient(config.BASE_URL)
 
   it('should fail if Safe address is empty', async () => {
     const safeAddress = ''

--- a/packages/safe-service-client/e2e/getSafesByOwner.test.ts
+++ b/packages/safe-service-client/e2e/getSafesByOwner.test.ts
@@ -6,7 +6,7 @@ import config from './config'
 chai.use(chaiAsPromised)
 
 describe('getSafesByOwner', () => {
-  const serviceSdk = new SafeServiceClient(config.baseUrl)
+  const serviceSdk = new SafeServiceClient(config.BASE_URL)
 
   it('should fail if owner address is empty', async () => {
     const ownerAddress = ''

--- a/packages/safe-service-client/e2e/getServiceInfo.test.ts
+++ b/packages/safe-service-client/e2e/getServiceInfo.test.ts
@@ -3,7 +3,7 @@ import SafeServiceClient, { SafeServiceInfoResponse } from '../src'
 import config from './config'
 
 describe('getServiceInfo', () => {
-  const serviceSdk = new SafeServiceClient(config.baseUrl)
+  const serviceSdk = new SafeServiceClient(config.BASE_URL)
 
   it('should return the Safe info', async () => {
     const safeInfo: SafeServiceInfoResponse = await serviceSdk.getServiceInfo()

--- a/packages/safe-service-client/e2e/getServiceMastercopiesInfo.test.ts
+++ b/packages/safe-service-client/e2e/getServiceMastercopiesInfo.test.ts
@@ -3,7 +3,7 @@ import SafeServiceClient, { MasterCopyResponse } from '../src'
 import config from './config'
 
 describe('getServiceMasterCopiesInfo', () => {
-  const serviceSdk = new SafeServiceClient(config.baseUrl)
+  const serviceSdk = new SafeServiceClient(config.BASE_URL)
 
   it('should call getServiceMasterCopiesInfo', async () => {
     const masterCopiesResponse: MasterCopyResponse[] = await serviceSdk.getServiceMasterCopiesInfo()

--- a/packages/safe-service-client/e2e/getToken.test.ts
+++ b/packages/safe-service-client/e2e/getToken.test.ts
@@ -6,7 +6,7 @@ import config from './config'
 chai.use(chaiAsPromised)
 
 describe('getToken', () => {
-  const serviceSdk = new SafeServiceClient(config.baseUrl)
+  const serviceSdk = new SafeServiceClient(config.BASE_URL)
 
   it('should fail if token address is empty', async () => {
     const tokenAddress = ''

--- a/packages/safe-service-client/e2e/getTokenList.test.ts
+++ b/packages/safe-service-client/e2e/getTokenList.test.ts
@@ -3,7 +3,7 @@ import SafeServiceClient, { TokenInfoListResponse } from '../src'
 import config from './config'
 
 describe('getTokenList', () => {
-  const serviceSdk = new SafeServiceClient(config.baseUrl)
+  const serviceSdk = new SafeServiceClient(config.BASE_URL)
 
   it('should return an array of tokens', async () => {
     const tokenInfoListResponse: TokenInfoListResponse = await serviceSdk.getTokenList()

--- a/packages/safe-service-client/e2e/getTransaction.test.ts
+++ b/packages/safe-service-client/e2e/getTransaction.test.ts
@@ -6,7 +6,7 @@ import config from './config'
 chai.use(chaiAsPromised)
 
 describe('getTransaction', () => {
-  const serviceSdk = new SafeServiceClient(config.baseUrl)
+  const serviceSdk = new SafeServiceClient(config.BASE_URL)
 
   it('should fail if safeTxHash is empty', async () => {
     const safeTxHash = ''

--- a/packages/safe-service-client/e2e/getTransactionConfirmations.test.ts
+++ b/packages/safe-service-client/e2e/getTransactionConfirmations.test.ts
@@ -6,7 +6,7 @@ import config from './config'
 chai.use(chaiAsPromised)
 
 describe('getTransactionConfirmations', () => {
-  const serviceSdk = new SafeServiceClient(config.baseUrl)
+  const serviceSdk = new SafeServiceClient(config.BASE_URL)
 
   it('should fail if safeTxHash is empty', async () => {
     const safeTxHash = ''

--- a/packages/safe-service-client/e2e/getUsdBalances.test.ts
+++ b/packages/safe-service-client/e2e/getUsdBalances.test.ts
@@ -6,7 +6,7 @@ import config from './config'
 chai.use(chaiAsPromised)
 
 describe('getUsdBalances', () => {
-  const serviceSdk = new SafeServiceClient(config.baseUrl)
+  const serviceSdk = new SafeServiceClient(config.BASE_URL)
 
   it('should fail if Safe address is empty', async () => {
     const safeAddress = ''

--- a/packages/safe-service-client/e2e/removeAllSafeDelegates.test.ts
+++ b/packages/safe-service-client/e2e/removeAllSafeDelegates.test.ts
@@ -1,0 +1,90 @@
+import { getDefaultProvider } from '@ethersproject/providers'
+import { Wallet } from '@ethersproject/wallet'
+import chai from 'chai'
+import chaiAsPromised from 'chai-as-promised'
+import SafeServiceClient, { SafeDelegateConfig } from '../src'
+import config from './config'
+chai.use(chaiAsPromised)
+
+describe('removeAllSafeDelegates', () => {
+  const serviceSdk = new SafeServiceClient(config.BASE_URL)
+
+  it('should fail if Safe address is empty', async () => {
+    const safeAddress = ''
+    const provider = getDefaultProvider(config.JSON_RPC)
+    const signer = new Wallet(
+      '0x4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d', // A Safe owner
+      provider
+    )
+    await chai
+      .expect(serviceSdk.removeAllSafeDelegates(safeAddress, signer))
+      .to.be.rejectedWith('Invalid Safe address')
+  })
+
+  it('should fail if Safe address is not checksummed', async () => {
+    const safeAddress = '0xf9A2FAa4E3b140ad42AAE8Cac4958cFf38Ab08fD'.toLowerCase()
+    const provider = getDefaultProvider(config.JSON_RPC)
+    const signer = new Wallet(
+      '0x4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d', // A Safe owner
+      provider
+    )
+    await chai
+      .expect(serviceSdk.removeAllSafeDelegates(safeAddress, signer))
+      .to.be.rejectedWith('Checksum address validation failed')
+  })
+
+  it('should fail if Safe does not exist', async () => {
+    const safeAddress = '0x1dF62f291b2E969fB0849d99D9Ce41e2F137006e'
+    const provider = getDefaultProvider(config.JSON_RPC)
+    const signer = new Wallet(
+      '0x4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d', // A Safe owner
+      provider
+    )
+    await chai
+      .expect(serviceSdk.removeAllSafeDelegates(safeAddress, signer))
+      .to.be.rejectedWith(`Safe=${safeAddress} does not exist or it's still not indexed`)
+  })
+
+  it('should fail if the signer is not an owner of the Safe', async () => {
+    const safeAddress = '0xf9A2FAa4E3b140ad42AAE8Cac4958cFf38Ab08fD'
+    const provider = getDefaultProvider(config.JSON_RPC)
+    const signer = new Wallet(
+      '0xb0057716d5917badaf911b193b12b910811c1497b5bada8d7711f758981c3773', // Not a Safe owner
+      provider
+    )
+    await chai
+      .expect(serviceSdk.removeAllSafeDelegates(safeAddress, signer))
+      .to.be.rejectedWith('Signing owner is not an owner of the Safe')
+  })
+
+  it('should remove all delegates', async () => {
+    const safeAddress = '0xf9A2FAa4E3b140ad42AAE8Cac4958cFf38Ab08fD'
+    const provider = getDefaultProvider(config.JSON_RPC)
+    const signer = new Wallet(
+      '0x4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d', // A Safe owner
+      provider
+    )
+
+    const delegateConfig1: SafeDelegateConfig = {
+      safe: safeAddress,
+      delegate: '0xFFcf8FDEE72ac11b5c542428B35EEF5769C409f0',
+      signer,
+      label: 'Label1'
+    }
+    const delegateConfig2: SafeDelegateConfig = {
+      safe: safeAddress,
+      delegate: '0x22d491Bde2303f2f43325b2108D26f1eAbA1e32b',
+      signer,
+      label: 'Label2'
+    }
+    await serviceSdk.addSafeDelegate(delegateConfig1)
+    await serviceSdk.addSafeDelegate(delegateConfig2)
+    const { results: initialDelegates } = await serviceSdk.getSafeDelegates(safeAddress)
+    chai.expect(initialDelegates.length).to.be.eq(2)
+
+    await serviceSdk.removeAllSafeDelegates(safeAddress, signer)
+
+    const { results: finalDelegates } = await serviceSdk.getSafeDelegates(safeAddress)
+    chai.expect(finalDelegates.length).to.be.eq(0)
+  })
+})

--- a/packages/safe-service-client/e2e/removeSafeDelegate.test.ts
+++ b/packages/safe-service-client/e2e/removeSafeDelegate.test.ts
@@ -1,0 +1,158 @@
+import { getDefaultProvider } from '@ethersproject/providers'
+import { Wallet } from '@ethersproject/wallet'
+import chai from 'chai'
+import chaiAsPromised from 'chai-as-promised'
+import SafeServiceClient, { SafeDelegateDeleteConfig } from '../src'
+import config from './config'
+chai.use(chaiAsPromised)
+
+describe('removeSafeDelegate', () => {
+  const serviceSdk = new SafeServiceClient(config.BASE_URL)
+
+  it('should fail if Safe address is empty', async () => {
+    const safeAddress = ''
+    const delegateAddress = '0xFFcf8FDEE72ac11b5c542428B35EEF5769C409f0'
+    const provider = getDefaultProvider(config.JSON_RPC)
+    const signer = new Wallet(
+      '0x4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d', // A Safe owner
+      provider
+    )
+    const delegateConfig: SafeDelegateDeleteConfig = {
+      safe: safeAddress,
+      delegate: delegateAddress,
+      signer
+    }
+    await chai
+      .expect(serviceSdk.removeSafeDelegate(delegateConfig))
+      .to.be.rejectedWith('Invalid Safe address')
+  })
+
+  it('should fail if Safe delegate address is empty', async () => {
+    const safeAddress = '0xf9A2FAa4E3b140ad42AAE8Cac4958cFf38Ab08fD'
+    const delegateAddress = ''
+    const provider = getDefaultProvider(config.JSON_RPC)
+    const signer = new Wallet(
+      '0x4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d', // A Safe owner
+      provider
+    )
+    const delegateConfig: SafeDelegateDeleteConfig = {
+      safe: safeAddress,
+      delegate: delegateAddress,
+      signer
+    }
+    await chai
+      .expect(serviceSdk.removeSafeDelegate(delegateConfig))
+      .to.be.rejectedWith('Invalid Safe delegate address')
+  })
+
+  it('should fail if Safe address is not checksummed', async () => {
+    const safeAddress = '0xf9A2FAa4E3b140ad42AAE8Cac4958cFf38Ab08fD'.toLowerCase()
+    const provider = getDefaultProvider(config.JSON_RPC)
+    const signer = new Wallet(
+      '0x4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d', // A Safe owner
+      provider
+    )
+    const delegateConfig: SafeDelegateDeleteConfig = {
+      safe: safeAddress,
+      delegate: '0xFFcf8FDEE72ac11b5c542428B35EEF5769C409f0',
+      signer
+    }
+    await chai
+      .expect(serviceSdk.removeSafeDelegate(delegateConfig))
+      .to.be.rejectedWith('Checksum address validation failed')
+  })
+
+  it('should fail if Safe delegate address is not checksummed', async () => {
+    const safeAddress = '0xf9A2FAa4E3b140ad42AAE8Cac4958cFf38Ab08fD'
+    const delegateAddress = '0xFFcf8FDEE72ac11b5c542428B35EEF5769C409f0'.toLowerCase()
+    const provider = getDefaultProvider(config.JSON_RPC)
+    const signer = new Wallet(
+      '0x4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d', // A Safe owner
+      provider
+    )
+    const delegateConfig: SafeDelegateDeleteConfig = {
+      safe: safeAddress,
+      delegate: delegateAddress,
+      signer
+    }
+    await chai
+      .expect(serviceSdk.removeSafeDelegate(delegateConfig))
+      .to.be.rejectedWith('Checksum address validation failed')
+  })
+
+  it('should fail if Safe does not exist', async () => {
+    const safeAddress = '0x1dF62f291b2E969fB0849d99D9Ce41e2F137006e'
+    const delegateAddress = '0xFFcf8FDEE72ac11b5c542428B35EEF5769C409f0'
+    const provider = getDefaultProvider(config.JSON_RPC)
+    const signer = new Wallet(
+      '0x4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d', // A Safe owner
+      provider
+    )
+    const delegateConfig: SafeDelegateDeleteConfig = {
+      safe: safeAddress,
+      delegate: delegateAddress,
+      signer
+    }
+    await chai
+      .expect(serviceSdk.removeSafeDelegate(delegateConfig))
+      .to.be.rejectedWith(`Safe=${safeAddress} does not exist or it's still not indexed`)
+  })
+
+  it('should fail if the signer is not an owner of the Safe', async () => {
+    const safeAddress = '0xf9A2FAa4E3b140ad42AAE8Cac4958cFf38Ab08fD'
+    const delegateAddress = '0xFFcf8FDEE72ac11b5c542428B35EEF5769C409f0'
+    const provider = getDefaultProvider(config.JSON_RPC)
+    const signer = new Wallet(
+      '0xb0057716d5917badaf911b193b12b910811c1497b5bada8d7711f758981c3773', // Not a Safe owner
+      provider
+    )
+    const delegateConfig: SafeDelegateDeleteConfig = {
+      safe: safeAddress,
+      delegate: delegateAddress,
+      signer
+    }
+    await chai
+      .expect(serviceSdk.removeSafeDelegate(delegateConfig))
+      .to.be.rejectedWith('Signing owner is not an owner of the Safe')
+  })
+
+  it('should fail if the delegate to remove is not a delegate', async () => {
+    const safeAddress = '0xf9A2FAa4E3b140ad42AAE8Cac4958cFf38Ab08fD'
+    const delegateAddress = '0x1dF62f291b2E969fB0849d99D9Ce41e2F137006e'
+    const provider = getDefaultProvider(config.JSON_RPC)
+    const signer = new Wallet(
+      '0x4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d', // A Safe owner
+      provider
+    )
+    const delegateConfig: SafeDelegateDeleteConfig = {
+      safe: safeAddress,
+      delegate: delegateAddress,
+      signer
+    }
+    await chai.expect(serviceSdk.removeSafeDelegate(delegateConfig)).to.be.rejectedWith('Not found')
+  })
+
+  it('should remove a delegate', async () => {
+    const safeAddress = '0xf9A2FAa4E3b140ad42AAE8Cac4958cFf38Ab08fD'
+    const delegateAddress = '0xFFcf8FDEE72ac11b5c542428B35EEF5769C409f0'
+    const provider = getDefaultProvider(config.JSON_RPC)
+    const signer = new Wallet(
+      '0x4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d', // A Safe owner
+      provider
+    )
+    const delegateConfig: SafeDelegateDeleteConfig = {
+      safe: safeAddress,
+      delegate: delegateAddress,
+      signer
+    }
+
+    await serviceSdk.addSafeDelegate({ ...delegateConfig, label: 'Label' })
+    const { results: initialDelegates } = await serviceSdk.getSafeDelegates(safeAddress)
+    chai.expect(initialDelegates.length).to.be.eq(1)
+
+    await serviceSdk.removeSafeDelegate(delegateConfig)
+
+    const { results: finalDelegates } = await serviceSdk.getSafeDelegates(safeAddress)
+    chai.expect(finalDelegates.length).to.be.eq(0)
+  })
+})

--- a/packages/safe-service-client/hardhat.config.ts
+++ b/packages/safe-service-client/hardhat.config.ts
@@ -1,0 +1,52 @@
+import '@nomiclabs/hardhat-ethers'
+import '@nomiclabs/hardhat-waffle'
+import dotenv from 'dotenv'
+import { HardhatUserConfig, HttpNetworkUserConfig } from 'hardhat/types'
+import yargs from 'yargs'
+
+const argv = yargs
+  .option('network', {
+    type: 'string',
+    default: 'hardhat',
+  })
+  .help(false)
+  .version(false).argv
+
+dotenv.config()
+const { INFURA_KEY, MNEMONIC, PK } = process.env
+const DEFAULT_MNEMONIC = 'myth like bonus scare over problem client lizard pioneer submit female collect'
+
+const sharedNetworkConfig: HttpNetworkUserConfig = {}
+if (PK) {
+  sharedNetworkConfig.accounts = [PK];
+} else {
+  sharedNetworkConfig.accounts = {
+    mnemonic: MNEMONIC || DEFAULT_MNEMONIC,
+  }
+}
+
+if (['rinkeby'].includes(argv.network) && INFURA_KEY === undefined) {
+  throw new Error(
+    `Could not find Infura key in env, unable to connect to network ${argv.network}`,
+  )
+}
+
+const config: HardhatUserConfig = {
+  defaultNetwork: "rinkeby",
+  paths: {
+    tests: 'e2e'
+  },
+  networks: {
+    hardhat: {
+      allowUnlimitedContractSize: true,
+      blockGasLimit: 100000000,
+      gas: 100000000
+    },
+    rinkeby: {
+      ...sharedNetworkConfig,
+      url: `https://rinkeby.infura.io/v3/${INFURA_KEY}`,
+    }
+  }
+}
+
+export default config

--- a/packages/safe-service-client/package.json
+++ b/packages/safe-service-client/package.json
@@ -14,7 +14,7 @@
     "unbuild": "rimraf dist",
     "build": "yarn rimraf dist && tsc",
     "test": "mocha --require ts-node/register tests/**/*.test.ts",
-    "test:ci": "mocha --require ts-node/register e2e/**/*.test.ts",
+    "test:ci": "nyc hardhat test",
     "format": "prettier --write \"{src,tests,e2e}/**/*.ts\"",
     "lint": "tslint -p tsconfig.json"
   },
@@ -33,7 +33,8 @@
   ],
   "homepage": "https://github.com/gnosis/safe-core-sdk#readme",
   "devDependencies": {
-    "@gnosis.pm/safe-core-sdk": "^0.3.1",
+    "@nomiclabs/hardhat-ethers": "^2.0.2",
+    "@nomiclabs/hardhat-waffle": "^2.0.1",
     "@types/chai": "^4.2.22",
     "@types/chai-as-promised": "^7.1.4",
     "@types/mocha": "^9.0.0",
@@ -45,6 +46,7 @@
     "eslint": "^7.32.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-prettier": "^4.0.0",
+    "hardhat": "^2.3.3",
     "husky": "^7.0.2",
     "lint-staged": "^11.1.2",
     "mocha": "^9.1.1",

--- a/packages/safe-service-client/src/SafeServiceClient.ts
+++ b/packages/safe-service-client/src/SafeServiceClient.ts
@@ -221,6 +221,25 @@ class SafeServiceClient implements SafeTransactionService {
   }
 
   /**
+   * Removes all delegates for a given Safe address. The signature is calculated by signing this hash: keccak(address + str(int(current_epoch / 3600))).
+   *
+   * @param safeAddress - The Safe address
+   * @returns
+   * @throws "Invalid Safe address"
+   * @throws "Malformed data"
+   * @throws "Invalid Ethereum address/Error processing data"
+   */
+  async removeAllSafeDelegates(safeAddress: string): Promise<any> {
+    if (safeAddress === '') {
+      throw new Error('Invalid Safe address')
+    }
+    return sendRequest({
+      url: `${this.#txServiceBaseUrl}/safes/${safeAddress}/delegates/`,
+      method: HttpMethod.Delete
+    })
+  }
+
+  /**
    * Removes a delegate for a given Safe address. The signature is calculated by signing this hash: keccak(address + str(int(current_epoch / 3600))).
    *
    * @param safeAddress - The Safe address

--- a/packages/safe-service-client/src/SafeServiceClient.ts
+++ b/packages/safe-service-client/src/SafeServiceClient.ts
@@ -1,3 +1,4 @@
+import { Signer } from '@ethersproject/abstract-signer'
 import { SafeSignature, SafeTransactionData } from '@gnosis.pm/safe-core-sdk-types'
 import SafeTransactionService from './SafeTransactionService'
 import {
@@ -11,7 +12,8 @@ import {
   SafeCollectiblesOptions,
   SafeCreationInfoResponse,
   SafeDelegate,
-  SafeDelegateDelete,
+  SafeDelegateConfig,
+  SafeDelegateDeleteConfig,
   SafeDelegateListResponse,
   SafeInfoResponse,
   SafeModuleTransactionListResponse,
@@ -186,8 +188,7 @@ class SafeServiceClient implements SafeTransactionService {
    * @param safeAddress - The Safe address
    * @returns The list of delegates
    * @throws "Invalid Safe address"
-   * @throws "Invalid data"
-   * @throws "Invalid ethereum address"
+   * @throws "Checksum address validation failed"
    */
   async getSafeDelegates(safeAddress: string): Promise<SafeDelegateListResponse> {
     if (safeAddress === '') {
@@ -200,63 +201,97 @@ class SafeServiceClient implements SafeTransactionService {
   }
 
   /**
-   * Adds a new delegate for a given Safe address. The signature is calculated by signing this hash: keccak(address + str(int(current_epoch / 3600))).
+   * Adds a new delegate for a given Safe address.
    *
    * @param safeAddress - The Safe address
-   * @param delegate - The new delegate
+   * @param delegateConfig - The configuration of the new delegate
    * @returns
    * @throws "Invalid Safe address"
-   * @throws "Malformed data"
-   * @throws "Invalid Ethereum address/Error processing data"
+   * @throws "Invalid Safe delegate address"
+   * @throws "Checksum address validation failed"
+   * @throws "Address <delegate_address> is not checksumed"
+   * @throws "Safe=<safe_address> does not exist or it's still not indexed"
+   * @throws "Signing owner is not an owner of the Safe"
    */
-  async addSafeDelegate(safeAddress: string, delegate: SafeDelegate): Promise<any> {
-    if (safeAddress === '') {
+  async addSafeDelegate(delegateConfig: SafeDelegateConfig): Promise<SafeDelegate> {
+    const { safe, delegate, label, signer } = delegateConfig
+    if (safe === '') {
       throw new Error('Invalid Safe address')
     }
+    if (delegate === '') {
+      throw new Error('Invalid Safe delegate address')
+    }
+    const totp = Math.floor(Date.now() / 1000 / 3600)
+    const data = delegate + totp
+    const signature = await signer.signMessage(data)
+    const body: SafeDelegate = {
+      safe,
+      delegate,
+      label,
+      signature
+    }
     return sendRequest({
-      url: `${this.#txServiceBaseUrl}/safes/${safeAddress}/delegates/`,
+      url: `${this.#txServiceBaseUrl}/safes/${safe}/delegates/`,
       method: HttpMethod.Post,
-      body: delegate
+      body
     })
   }
 
   /**
-   * Removes all delegates for a given Safe address. The signature is calculated by signing this hash: keccak(address + str(int(current_epoch / 3600))).
+   * Removes all delegates for a given Safe address.
    *
    * @param safeAddress - The Safe address
    * @returns
    * @throws "Invalid Safe address"
-   * @throws "Malformed data"
-   * @throws "Invalid Ethereum address/Error processing data"
+   * @throws "Checksum address validation failed"
+   * @throws "Safe=<safe_address> does not exist or it's still not indexed"
+   * @throws "Signing owner is not an owner of the Safe"
    */
-  async removeAllSafeDelegates(safeAddress: string): Promise<any> {
+  async removeAllSafeDelegates(safeAddress: string, signer: Signer): Promise<void> {
     if (safeAddress === '') {
       throw new Error('Invalid Safe address')
     }
+    const totp = Math.floor(Date.now() / 1000 / 3600)
+    const data = safeAddress + totp
+    const signature = await signer.signMessage(data)
     return sendRequest({
       url: `${this.#txServiceBaseUrl}/safes/${safeAddress}/delegates/`,
-      method: HttpMethod.Delete
+      method: HttpMethod.Delete,
+      body: { signature }
     })
   }
 
   /**
-   * Removes a delegate for a given Safe address. The signature is calculated by signing this hash: keccak(address + str(int(current_epoch / 3600))).
+   * Removes a delegate for a given Safe address.
    *
    * @param safeAddress - The Safe address
-   * @param delegate - The delegate that will be removed
+   * @param delegateConfig - The configuration for the delegate that will be removed
    * @returns
    * @throws "Invalid Safe address"
-   * @throws "Malformed data"
-   * @throws "Invalid Ethereum address/Error processing data"
+   * @throws "Invalid Safe delegate address"
+   * @throws "Checksum address validation failed"
+   * @throws "Signing owner is not an owner of the Safe"
+   * @throws "Not found"
    */
-  async removeSafeDelegate(safeAddress: string, delegate: SafeDelegateDelete): Promise<any> {
-    if (safeAddress === '') {
+  async removeSafeDelegate(delegateConfig: SafeDelegateDeleteConfig): Promise<void> {
+    const { safe, delegate, signer } = delegateConfig
+    if (safe === '') {
       throw new Error('Invalid Safe address')
     }
+    if (delegate === '') {
+      throw new Error('Invalid Safe delegate address')
+    }
+    const totp = Math.floor(Date.now() / 1000 / 3600)
+    const data = delegate + totp
+    const signature = await signer.signMessage(data)
     return sendRequest({
-      url: `${this.#txServiceBaseUrl}/safes/${safeAddress}/delegates/${delegate.delegate}`,
+      url: `${this.#txServiceBaseUrl}/safes/${safe}/delegates/${delegate}`,
       method: HttpMethod.Delete,
-      body: delegate
+      body: {
+        safe,
+        delegate,
+        signature
+      }
     })
   }
 

--- a/packages/safe-service-client/src/SafeTransactionService.ts
+++ b/packages/safe-service-client/src/SafeTransactionService.ts
@@ -1,3 +1,4 @@
+import { Signer } from '@ethersproject/abstract-signer'
 import { SafeSignature, SafeTransactionData } from '@gnosis.pm/safe-core-sdk-types'
 import {
   MasterCopyResponse,
@@ -10,7 +11,8 @@ import {
   SafeCollectiblesOptions,
   SafeCreationInfoResponse,
   SafeDelegate,
-  SafeDelegateDelete,
+  SafeDelegateConfig,
+  SafeDelegateDeleteConfig,
   SafeDelegateListResponse,
   SafeInfoResponse,
   SafeModuleTransactionListResponse,
@@ -45,8 +47,9 @@ interface SafeTransactionService {
   // Safes
   getSafeInfo(safeAddress: string): Promise<SafeInfoResponse>
   getSafeDelegates(safeAddress: string): Promise<SafeDelegateListResponse>
-  addSafeDelegate(safeAddress: string, delegate: SafeDelegate): Promise<any>
-  removeSafeDelegate(safeAddress: string, delegate: SafeDelegateDelete): Promise<any>
+  addSafeDelegate(config: SafeDelegateConfig): Promise<SafeDelegate>
+  removeSafeDelegate(config: SafeDelegateDeleteConfig): Promise<void>
+  removeAllSafeDelegates(safeAddress: string, signer: Signer): Promise<void>
 
   // Transactions
   getSafeCreationInfo(safeAddress: string): Promise<SafeCreationInfoResponse>

--- a/packages/safe-service-client/src/types/safeTransactionServiceTypes.ts
+++ b/packages/safe-service-client/src/types/safeTransactionServiceTypes.ts
@@ -1,3 +1,5 @@
+import { Signer } from '@ethersproject/abstract-signer'
+
 export type SafeServiceInfoResponse = {
   readonly name: string
   readonly version: string
@@ -49,17 +51,21 @@ export type SafeCreationInfoResponse = {
   readonly dataDecoded?: string
 }
 
+export type SafeDelegateDeleteConfig = {
+  readonly safe: string
+  readonly delegate: string
+  readonly signer: Signer
+}
+
+export type SafeDelegateConfig = SafeDelegateDeleteConfig & {
+  readonly label: string
+}
+
 export type SafeDelegate = {
   readonly safe: string
   readonly delegate: string
   readonly signature: string
   readonly label: string
-}
-
-export type SafeDelegateDelete = {
-  readonly safe: string
-  readonly delegate: string
-  readonly signature: string
 }
 
 export type SafeDelegateResponse = {

--- a/packages/safe-service-client/src/utils/httpRequests.ts
+++ b/packages/safe-service-client/src/utils/httpRequests.ts
@@ -21,12 +21,16 @@ export async function sendRequest<T>({ url, method, body }: HttpRequest): Promis
     },
     body: JSON.stringify(body)
   })
+
   let jsonResponse
   try {
     jsonResponse = await response.json()
   } catch (error) {
-    throw new Error(response.statusText)
+    if (!response.ok) {
+      throw new Error(response.statusText)
+    }
   }
+
   if (response.ok) {
     return jsonResponse as T
   }
@@ -38,6 +42,12 @@ export async function sendRequest<T>({ url, method, body }: HttpRequest): Promis
   }
   if (jsonResponse.message) {
     throw new Error(jsonResponse.message)
+  }
+  if (jsonResponse.nonFieldErrors) {
+    throw new Error(jsonResponse.nonFieldErrors)
+  }
+  if (jsonResponse.delegate) {
+    throw new Error(jsonResponse.delegate)
   }
   throw new Error(response.statusText)
 }

--- a/packages/safe-service-client/tests/endpoint.test.ts
+++ b/packages/safe-service-client/tests/endpoint.test.ts
@@ -137,6 +137,16 @@ describe('Endpoint tests', () => {
       })
     })
 
+    it('removeAllSafeDelegates', async () => {
+      chai
+        .expect(serviceSdk.removeAllSafeDelegates(safeAddress))
+        .to.be.eventually.deep.equals({ success: true })
+      chai.expect(fetchData).to.have.been.calledWith({
+        url: `${getTxServiceBaseUrl(txServiceBaseUrl)}/safes/${safeAddress}/delegates/`,
+        method: 'delete'
+      })
+    })
+
     it('removeSafeDelegate', async () => {
       const delegate: SafeDelegateDelete = {
         safe: safeAddress,


### PR DESCRIPTION
Resolves #77

- Adds the method `removeAllSafeDelegates` to remove all the Safe delegates at once
- Replaces the `signature` param with a `signer` param
- Adds e2e tests for all the Safe delegate related methods
- Adds endpoint test for all the Safe delegate related methods