### PR TITLE
Fix L2 initialization

### DIFF
--- a/packages/safe-core-sdk/package.json
+++ b/packages/safe-core-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/safe-core-sdk",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Safe Core SDK",
   "main": "dist/src/index.js",
   "typings": "dist/src/index.d.ts",

--- a/packages/safe-core-sdk/src/managers/contractManager.ts
+++ b/packages/safe-core-sdk/src/managers/contractManager.ts
@@ -1,4 +1,4 @@
-import { SafeVersion, SAFE_BASE_VERSION } from '../contracts/config'
+import { SafeVersion, SAFE_LAST_VERSION } from '../contracts/config'
 import GnosisSafeContract from '../contracts/GnosisSafe/GnosisSafeContract'
 import MultiSendContract from '../contracts/MultiSend/MultiSendContract'
 import { SafeConfig } from '../Safe'
@@ -29,7 +29,7 @@ class ContractManager {
   }: SafeConfig): Promise<void> {
     const chainId = await ethAdapter.getChainId()
     const temporarySafeContract = ethAdapter.getSafeContract({
-      safeVersion: SAFE_BASE_VERSION,
+      safeVersion: SAFE_LAST_VERSION,
       chainId,
       isL1SafeMasterCopy,
       customContractAddress: safeAddress


### PR DESCRIPTION
## What it solves
The Master Copy address is obtained from `safe-deployments` based on the network and contract version.

When the SDK is initialized, to obtain the contract version we need to instantiate the contract and call the `VERSION()` method. This instance is called `temporarySafeContract` and uses the `SAFE_BASE_VERSION` (v1.1.1) just to obtain the contract version and instantiate the contract again with the real one.

When working with L2 contracts (GnosisSafeL2.sol) and Web3 provider (not Ethers), it fails because it tries to get the ABI from `safe-deployments` for the version v1.1.1, but that version does not have a GnosisSafeL2.sol contract. (It works using the flag `isL1SafeContract=true` but that forces to use a different Master Copy).

## How this PR fixes it
Uses v1.3.0 as the temporary Safe contract to prevent this.
