### PR TITLE
fixed missing required gas field in web3adapter tx calls

### DIFF
--- a/packages/safe-core-sdk/package.json
+++ b/packages/safe-core-sdk/package.json
@@ -92,7 +92,7 @@
   },
   "dependencies": {
     "@gnosis.pm/safe-core-sdk-types": "^0.1.1",
-    "@gnosis.pm/safe-deployments": "^1.5.0",
+    "@gnosis.pm/safe-deployments": "^1.7.0",
     "ethereumjs-util": "^7.1.3",
     "semver": "^7.3.5"
   }

--- a/packages/safe-core-sdk/src/Safe.ts
+++ b/packages/safe-core-sdk/src/Safe.ts
@@ -375,12 +375,8 @@ class Safe {
     if (!addressIsOwner) {
       throw new Error('Transaction hashes can only be approved by Safe owners')
     }
-    const estimate = await this.#contractManager.safeContract.estimateGas('approveHash', [hash], {
-      from: signerAddress
-    })
     return this.#contractManager.safeContract.approveHash(hash, {
-      from: signerAddress,
-      gas: estimate
+      from: signerAddress
     })
   }
 

--- a/packages/safe-core-sdk/src/Safe.ts
+++ b/packages/safe-core-sdk/src/Safe.ts
@@ -375,8 +375,12 @@ class Safe {
     if (!addressIsOwner) {
       throw new Error('Transaction hashes can only be approved by Safe owners')
     }
-    return this.#contractManager.safeContract.approveHash(hash, {
+    const estimate = await this.#contractManager.safeContract.estimateGas('approveHash', [hash], {
       from: signerAddress
+    })
+    return this.#contractManager.safeContract.approveHash(hash, {
+      from: signerAddress,
+      gas: estimate
     })
   }
 

--- a/packages/safe-core-sdk/src/contracts/GnosisSafe/GnosisSafeContractWeb3.ts
+++ b/packages/safe-core-sdk/src/contracts/GnosisSafe/GnosisSafeContractWeb3.ts
@@ -67,7 +67,11 @@ abstract class GnosisSafeContractWeb3 implements GnosisSafeContract {
   }
 
   async approveHash(hash: string, options?: TransactionOptions): Promise<Web3TransactionResult> {
-    const txResponse = this.contract.methods.approveHash(hash).send(options)
+    const tx = this.contract.methods.approveHash(hash)
+    if (options && !options.gas && !options.gasLimit) {
+      options.gas = await tx.estimateGas(options)
+    }
+    const txResponse = tx.send(options)
     return toTxResult(txResponse, options)
   }
 
@@ -79,7 +83,7 @@ abstract class GnosisSafeContractWeb3 implements GnosisSafeContract {
     safeTransaction: SafeTransaction,
     options?: TransactionOptions
   ): Promise<Web3TransactionResult> {
-    const txResponse = this.contract.methods
+    const tx = this.contract.methods
       .execTransaction(
         safeTransaction.data.to,
         safeTransaction.data.value,
@@ -92,7 +96,12 @@ abstract class GnosisSafeContractWeb3 implements GnosisSafeContract {
         safeTransaction.data.refundReceiver,
         safeTransaction.encodedSignatures()
       )
-      .send(options)
+
+    if (options && !options.gas && !options.gasLimit) {
+      options.gas = await tx.estimateGas(options)
+    }
+
+    const txResponse = tx.send(options)
     return toTxResult(txResponse, options)
   }
 

--- a/packages/safe-core-sdk/src/contracts/GnosisSafeProxyFactory/GnosisSafeProxyFactoryWeb3Contract.ts
+++ b/packages/safe-core-sdk/src/contracts/GnosisSafeProxyFactory/GnosisSafeProxyFactoryWeb3Contract.ts
@@ -22,7 +22,7 @@ class GnosisSafeProxyFactoryWeb3Contract implements GnosisSafeProxyFactoryContra
       saltNonce
     )
 
-    if (options && !options.gas) {
+    if (options && !options.gasLimit && !options.gas) {
       options.gas = await tx.estimateGas(options)
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1251,10 +1251,10 @@
   resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-deployments/-/safe-deployments-1.4.0.tgz#d49d3d36cc014ef62306d09c0f4761895a17d7a6"
   integrity sha512-q4salJNQ/Gx0DnZJytAFO/U4OwGI6xTGtTJSOZK+C9Fh2NW8sep+YfSunHQvCLcu4b7WgWEBhxnCV6rpyveLHg==
 
-"@gnosis.pm/safe-deployments@^1.5.0":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-deployments/-/safe-deployments-1.5.0.tgz#5e01ccc2e2d78bf91ecb4453a64d1cac3a5ba2d6"
-  integrity sha512-IDU7I+IQr1zUU94/uD8shDVI+/nUA1unQUg8jtbTG0YGcmm49Lu8G01rqtWt2mhLxZWzFsgbLWGnU+/BzUqk7g==
+"@gnosis.pm/safe-deployments@^1.7.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-deployments/-/safe-deployments-1.7.0.tgz#dd5fde901595545131d447888e327cc72e41d370"
+  integrity sha512-OWc73XDBOJzoDk7GAQsasOxHnXKdJdOb28Jkv+JNie2LlRwZe1SMCu0iTozhwpLFp4BC+iDtuVWN7EVpe142ag==
 
 "@graphql-tools/batch-delegate@^6.2.4", "@graphql-tools/batch-delegate@^6.2.6":
   version "6.2.6"


### PR DESCRIPTION
## What it solves
Resolves issue https://github.com/gnosis/safe-core-sdk/issues/132

## How this PR fixes it

- It adds missing gas property to send transactions in web3 where it's missing
- replaces reading first event with appropriate `ProxyCreation` event