### PR TITLE
Fix contract calls in class GnosisSafeContract_V1_1_1

### DIFF
--- a/packages/safe-core-sdk/src/contracts/GnosisSafe/v1.1.1/GnosisSafeContract_V1_1_1_Ethers.ts
+++ b/packages/safe-core-sdk/src/contracts/GnosisSafe/v1.1.1/GnosisSafeContract_V1_1_1_Ethers.ts
@@ -8,7 +8,7 @@ class GnosisSafeContract_V1_1_1_Ethers extends GnosisSafeContractEthers {
   }
 
   async getModules(): Promise<string[]> {
-    return (super.contract as GnosisSafe).getModules()
+    return this.contract.getModules()
   }
 
   async isModuleEnabled(moduleAddress: string): Promise<boolean> {

--- a/packages/safe-core-sdk/src/contracts/GnosisSafe/v1.1.1/GnosisSafeContract_V1_1_1_Web3.ts
+++ b/packages/safe-core-sdk/src/contracts/GnosisSafe/v1.1.1/GnosisSafeContract_V1_1_1_Web3.ts
@@ -8,7 +8,7 @@ class GnosisSafeContract_V1_1_1_Web3 extends GnosisSafeContractWeb3 {
   }
 
   async getModules(): Promise<string[]> {
-    return (super.contract as GnosisSafe).methods.getModules().call()
+    return this.contract.methods.getModules().call()
   }
 
   async isModuleEnabled(moduleAddress: string): Promise<boolean> {


### PR DESCRIPTION
## What it solves
`super.contract` is undefined in classes `GnosisSafeContract_V1_1_1_Ethers` and `GnosisSafeContract_V1_1_1_Web3`

## How this PR fixes it
Call `this.contract`