### PR TITLE
Update safe-deployments dependency to v1.7.0

### DIFF
--- a/packages/safe-core-sdk/package.json
+++ b/packages/safe-core-sdk/package.json
@@ -92,7 +92,7 @@
   },
   "dependencies": {
     "@gnosis.pm/safe-core-sdk-types": "^0.1.1",
-    "@gnosis.pm/safe-deployments": "^1.5.0",
+    "@gnosis.pm/safe-deployments": "^1.7.0",
     "ethereumjs-util": "^7.1.3",
     "semver": "^7.3.5"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1251,7 +1251,7 @@
   resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-deployments/-/safe-deployments-1.4.0.tgz#d49d3d36cc014ef62306d09c0f4761895a17d7a6"
   integrity sha512-q4salJNQ/Gx0DnZJytAFO/U4OwGI6xTGtTJSOZK+C9Fh2NW8sep+YfSunHQvCLcu4b7WgWEBhxnCV6rpyveLHg==
 
-"@gnosis.pm/safe-deployments@^1.5.0":
+"@gnosis.pm/safe-deployments@^1.7.0":
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-deployments/-/safe-deployments-1.7.0.tgz#dd5fde901595545131d447888e327cc72e41d370"
   integrity sha512-OWc73XDBOJzoDk7GAQsasOxHnXKdJdOb28Jkv+JNie2LlRwZe1SMCu0iTozhwpLFp4BC+iDtuVWN7EVpe142ag==


### PR DESCRIPTION
Update safe-deployments dependency to v1.7.0 in Safe Core SDK