### PR TITLE
Update safe-deployments to v1.8.0

### DIFF
--- a/packages/safe-core-sdk/package.json
+++ b/packages/safe-core-sdk/package.json
@@ -92,7 +92,7 @@
   },
   "dependencies": {
     "@gnosis.pm/safe-core-sdk-types": "^0.1.1",
-    "@gnosis.pm/safe-deployments": "^1.7.0",
+    "@gnosis.pm/safe-deployments": "^1.8.0",
     "ethereumjs-util": "^7.1.3",
     "semver": "^7.3.5"
   }


### PR DESCRIPTION
Adding version 1.8.0 of safe-deployment with Moonbeam configuration

## What it solves
Resolves # Unable to access features of SDK on moonbeam network

## How this PR fixes it
https://github.com/gnosis/safe-deployments/pull/58

CC: @germartinez 