### PR TITLE
Chore: use yarn cache in the CI script

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,22 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
-      - run: |
-          yarn install
-          yarn build
-          yarn test
+
+      - name: Yarn cache
+        uses: actions/cache@v2
+        with:
+          path: '**/node_modules'
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+
+      - name: Yarn install
+        run: |
+          mkdir .yarncache
+          yarn install --cache-folder ./.yarncache --frozen-lockfile
+          rm -rf .yarncache
+          yarn cache clean
+
+      - name: Build
+        run: yarn build
+
+      - name: Test
+        run: yarn test

--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "scripts": {
     "clean": "lerna clean",
     "unbuild": "lerna run unbuild",
-    "build": "lerna run build --stream",
-    "test": "FORCE_COLOR=1 lerna run test --stream",
-    "test:ci": "FORCE_COLOR=1 lerna run test:ci --stream",
-    "format": "lerna run format"
+    "build": "lerna run build --stream --npm-client=yarn",
+    "test": "FORCE_COLOR=1 lerna run test --stream --npm-client=yarn",
+    "format": "lerna run format --npm-client=yarn",
+    "postinstall": "cd packages/safe-ethers-lib; hardhat compile"
   },
   "workspaces": {
     "packages": [


### PR DESCRIPTION
## What it solves
I've copied the same `yarn install` job as in safe-react.
It correctly uses a frozen lock file which ensures idempotent builds.