### PR TITLE
Fix safe version and refactor safe deployments functions

### DIFF
--- a/packages/safe-core-sdk/src/Safe.ts
+++ b/packages/safe-core-sdk/src/Safe.ts
@@ -77,8 +77,8 @@ class Safe {
    * Creates an instance of the Safe Core SDK.
    * @param config - Ethers Safe configuration
    * @returns The Safe Core SDK instance
-   * @throws "Safe Proxy contract is not deployed in the current network"
-   * @throws "MultiSend contract is not deployed in the current network"
+   * @throws "Safe Proxy contract is not deployed on the current network"
+   * @throws "MultiSend contract is not deployed on the current network"
    */
   static async create({
     ethAdapter,
@@ -95,8 +95,8 @@ class Safe {
    * Initializes the Safe Core SDK instance.
    * @param config - Safe configuration
    * @throws "Signer must be connected to a provider"
-   * @throws "Safe Proxy contract is not deployed in the current network"
-   * @throws "MultiSend contract is not deployed in the current network"
+   * @throws "Safe Proxy contract is not deployed on the current network"
+   * @throws "MultiSend contract is not deployed on the current network"
    */
   private async init({
     ethAdapter,
@@ -118,8 +118,8 @@ class Safe {
   /**
    * Returns a new instance of the Safe Core SDK.
    * @param config - Connect Safe configuration
-   * @throws "Safe Proxy contract is not deployed in the current network"
-   * @throws "MultiSend contract is not deployed in the current network"
+   * @throws "Safe Proxy contract is not deployed on the current network"
+   * @throws "MultiSend contract is not deployed on the current network"
    */
   async connect({
     ethAdapter,

--- a/packages/safe-core-sdk/src/contracts/safeDeploymentContracts.ts
+++ b/packages/safe-core-sdk/src/contracts/safeDeploymentContracts.ts
@@ -86,7 +86,7 @@ export async function getSafeContract({
   })
   const isContractDeployed = await ethAdapter.isContractDeployed(gnosisSafeContract.getAddress())
   if (!isContractDeployed) {
-    throw new Error('Safe Proxy contract is not deployed in the current network')
+    throw new Error('Safe Proxy contract is not deployed on the current network')
   }
   return gnosisSafeContract
 }
@@ -109,7 +109,7 @@ export async function getProxyFactoryContract({
     safeProxyFactoryContract.getAddress()
   )
   if (!isContractDeployed) {
-    throw new Error('Safe Proxy Factory contract is not deployed in the current network')
+    throw new Error('Safe Proxy Factory contract is not deployed on the current network')
   }
   return safeProxyFactoryContract
 }
@@ -130,7 +130,7 @@ export async function getMultiSendContract({
   })
   const isContractDeployed = await ethAdapter.isContractDeployed(multiSendContract.getAddress())
   if (!isContractDeployed) {
-    throw new Error('Multi Send contract is not deployed in the current network')
+    throw new Error('Multi Send contract is not deployed on the current network')
   }
   return multiSendContract
 }

--- a/packages/safe-core-sdk/src/contracts/safeDeploymentContracts.ts
+++ b/packages/safe-core-sdk/src/contracts/safeDeploymentContracts.ts
@@ -1,4 +1,10 @@
-import { SafeVersion } from '@gnosis.pm/safe-core-sdk-types'
+import {
+  EthAdapter,
+  GnosisSafeContract,
+  GnosisSafeProxyFactoryContract,
+  MultiSendContract,
+  SafeVersion
+} from '@gnosis.pm/safe-core-sdk-types'
 import {
   DeploymentFilter,
   getMultiSendDeployment,
@@ -7,7 +13,31 @@ import {
   getSafeSingletonDeployment,
   SingletonDeployment
 } from '@gnosis.pm/safe-deployments'
+import { ContractNetworkConfig } from '../types'
 import { safeDeploymentsL1ChainIds, safeDeploymentsVersions } from './config'
+
+interface GetSafeContractInstanceProps {
+  ethAdapter: EthAdapter
+  safeVersion: SafeVersion
+  chainId: number
+  isL1SafeMasterCopy?: boolean
+  customSafeAddress?: string
+  customContracts?: ContractNetworkConfig
+}
+
+interface GetProxyFactoryContractInstanceProps {
+  ethAdapter: EthAdapter
+  safeVersion: SafeVersion
+  chainId: number
+  customContracts?: ContractNetworkConfig
+}
+
+interface GetMultiSendContractInstanceProps {
+  ethAdapter: EthAdapter
+  safeVersion: SafeVersion
+  chainId: number
+  customContracts?: ContractNetworkConfig
+}
 
 export function getSafeContractDeployment(
   safeVersion: SafeVersion,
@@ -36,4 +66,71 @@ export function getSafeProxyFactoryContractDeployment(
 ): SingletonDeployment | undefined {
   const version = safeDeploymentsVersions[safeVersion].safeProxyFactoryVersion
   return getProxyFactoryDeployment({ version, network: chainId.toString(), released: true })
+}
+
+export async function getSafeContract({
+  ethAdapter,
+  safeVersion,
+  chainId,
+  customSafeAddress,
+  isL1SafeMasterCopy,
+  customContracts
+}: GetSafeContractInstanceProps): Promise<GnosisSafeContract> {
+  const singletonDeployment = getSafeContractDeployment(safeVersion, chainId, isL1SafeMasterCopy)
+  const gnosisSafeContract = ethAdapter.getSafeContract({
+    safeVersion,
+    chainId,
+    singletonDeployment,
+    customContractAddress: customSafeAddress ?? customContracts?.safeMasterCopyAddress,
+    customContractAbi: customContracts?.safeMasterCopyAbi
+  })
+  const isContractDeployed = await ethAdapter.isContractDeployed(gnosisSafeContract.getAddress())
+  if (!isContractDeployed) {
+    throw new Error('Safe Proxy contract is not deployed in the current network')
+  }
+  return gnosisSafeContract
+}
+
+export async function getProxyFactoryContract({
+  ethAdapter,
+  safeVersion,
+  chainId,
+  customContracts
+}: GetProxyFactoryContractInstanceProps): Promise<GnosisSafeProxyFactoryContract> {
+  const proxyFactoryDeployment = getSafeProxyFactoryContractDeployment(safeVersion, chainId)
+  const safeProxyFactoryContract = await ethAdapter.getSafeProxyFactoryContract({
+    safeVersion,
+    chainId,
+    singletonDeployment: proxyFactoryDeployment,
+    customContractAddress: customContracts?.safeProxyFactoryAddress,
+    customContractAbi: customContracts?.safeProxyFactoryAbi
+  })
+  const isContractDeployed = await ethAdapter.isContractDeployed(
+    safeProxyFactoryContract.getAddress()
+  )
+  if (!isContractDeployed) {
+    throw new Error('Safe Proxy Factory contract is not deployed in the current network')
+  }
+  return safeProxyFactoryContract
+}
+
+export async function getMultiSendContract({
+  ethAdapter,
+  safeVersion,
+  chainId,
+  customContracts
+}: GetMultiSendContractInstanceProps): Promise<MultiSendContract> {
+  const multiSendDeployment = getMultiSendContractDeployment(safeVersion, chainId)
+  const multiSendContract = await ethAdapter.getMultiSendContract({
+    safeVersion,
+    chainId,
+    singletonDeployment: multiSendDeployment,
+    customContractAddress: customContracts?.multiSendAddress,
+    customContractAbi: customContracts?.multiSendAbi
+  })
+  const isContractDeployed = await ethAdapter.isContractDeployed(multiSendContract.getAddress())
+  if (!isContractDeployed) {
+    throw new Error('Multi Send contract is not deployed in the current network')
+  }
+  return multiSendContract
 }

--- a/packages/safe-core-sdk/src/contracts/safeDeploymentContracts.ts
+++ b/packages/safe-core-sdk/src/contracts/safeDeploymentContracts.ts
@@ -16,27 +16,16 @@ import {
 import { ContractNetworkConfig } from '../types'
 import { safeDeploymentsL1ChainIds, safeDeploymentsVersions } from './config'
 
-interface GetSafeContractInstanceProps {
+interface GetContractInstanceProps {
   ethAdapter: EthAdapter
   safeVersion: SafeVersion
   chainId: number
+  customContracts?: ContractNetworkConfig
+}
+
+interface GetSafeContractInstanceProps extends GetContractInstanceProps {
   isL1SafeMasterCopy?: boolean
   customSafeAddress?: string
-  customContracts?: ContractNetworkConfig
-}
-
-interface GetProxyFactoryContractInstanceProps {
-  ethAdapter: EthAdapter
-  safeVersion: SafeVersion
-  chainId: number
-  customContracts?: ContractNetworkConfig
-}
-
-interface GetMultiSendContractInstanceProps {
-  ethAdapter: EthAdapter
-  safeVersion: SafeVersion
-  chainId: number
-  customContracts?: ContractNetworkConfig
 }
 
 export function getSafeContractDeployment(
@@ -96,7 +85,7 @@ export async function getProxyFactoryContract({
   safeVersion,
   chainId,
   customContracts
-}: GetProxyFactoryContractInstanceProps): Promise<GnosisSafeProxyFactoryContract> {
+}: GetContractInstanceProps): Promise<GnosisSafeProxyFactoryContract> {
   const proxyFactoryDeployment = getSafeProxyFactoryContractDeployment(safeVersion, chainId)
   const safeProxyFactoryContract = await ethAdapter.getSafeProxyFactoryContract({
     safeVersion,
@@ -119,7 +108,7 @@ export async function getMultiSendContract({
   safeVersion,
   chainId,
   customContracts
-}: GetMultiSendContractInstanceProps): Promise<MultiSendContract> {
+}: GetContractInstanceProps): Promise<MultiSendContract> {
   const multiSendDeployment = getMultiSendContractDeployment(safeVersion, chainId)
   const multiSendContract = await ethAdapter.getMultiSendContract({
     safeVersion,

--- a/packages/safe-core-sdk/src/managers/contractManager.ts
+++ b/packages/safe-core-sdk/src/managers/contractManager.ts
@@ -105,25 +105,25 @@ class ContractManager {
     isL1SafeMasterCopy,
     customContracts
   }: GetSafeContractInstanceProps): Promise<GnosisSafeContract> {
-    const safeSingletonDeployment = getSafeContractDeployment(
+    const singletonDeployment = getSafeContractDeployment(
       safeVersion,
       chainId,
       isL1SafeMasterCopy
     )
-    const temporarySafeContract = ethAdapter.getSafeContract({
-      safeVersion: SAFE_LAST_VERSION,
+    const gnosisSafeContract = ethAdapter.getSafeContract({
+      safeVersion,
       chainId,
-      singletonDeployment: safeSingletonDeployment,
+      singletonDeployment,
       customContractAddress: safeAddress,
       customContractAbi: customContracts?.safeMasterCopyAbi
     })
     const isContractDeployed = await ethAdapter.isContractDeployed(
-      temporarySafeContract.getAddress()
+      gnosisSafeContract.getAddress()
     )
     if (!isContractDeployed) {
       throw new Error('Safe Proxy contract is not deployed in the current network')
     }
-    return temporarySafeContract
+    return gnosisSafeContract
   }
 
   private async getMultiSendContract({

--- a/packages/safe-core-sdk/src/managers/contractManager.ts
+++ b/packages/safe-core-sdk/src/managers/contractManager.ts
@@ -1,32 +1,8 @@
-import {
-  EthAdapter,
-  GnosisSafeContract,
-  MultiSendContract,
-  SafeVersion
-} from '@gnosis.pm/safe-core-sdk-types'
+import { GnosisSafeContract, MultiSendContract } from '@gnosis.pm/safe-core-sdk-types'
 import { SAFE_LAST_VERSION } from '../contracts/config'
-import {
-  getMultiSendContractDeployment,
-  getSafeContractDeployment
-} from '../contracts/safeDeploymentContracts'
+import { getMultiSendContract, getSafeContract } from '../contracts/safeDeploymentContracts'
 import { SafeConfig } from '../Safe'
-import { ContractNetworkConfig, ContractNetworksConfig } from '../types'
-
-interface GetSafeContractInstanceProps {
-  ethAdapter: EthAdapter
-  safeVersion: SafeVersion
-  chainId: number
-  safeAddress: string
-  isL1SafeMasterCopy?: boolean
-  customContracts?: ContractNetworkConfig
-}
-
-interface GetMultiSendContractInstanceProps {
-  ethAdapter: EthAdapter
-  safeVersion: SafeVersion
-  chainId: number
-  customContracts?: ContractNetworkConfig
-}
+import { ContractNetworksConfig } from '../types'
 
 class ContractManager {
   #contractNetworks?: ContractNetworksConfig
@@ -56,24 +32,24 @@ class ContractManager {
     this.#contractNetworks = contractNetworks
     this.#isL1SafeMasterCopy = isL1SafeMasterCopy
 
-    const temporarySafeContract = await this.getSafeContract({
+    const temporarySafeContract = await getSafeContract({
       ethAdapter,
       safeVersion: SAFE_LAST_VERSION,
       chainId,
-      safeAddress,
       isL1SafeMasterCopy,
+      customSafeAddress: safeAddress,
       customContracts
     })
     const safeVersion = await temporarySafeContract.getVersion()
-    this.#safeContract = await this.getSafeContract({
+    this.#safeContract = await getSafeContract({
       ethAdapter,
       safeVersion,
       chainId,
-      safeAddress,
       isL1SafeMasterCopy,
+      customSafeAddress: safeAddress,
       customContracts
     })
-    this.#multiSendContract = await this.getMultiSendContract({
+    this.#multiSendContract = await getMultiSendContract({
       ethAdapter,
       safeVersion,
       chainId,
@@ -95,56 +71,6 @@ class ContractManager {
 
   get multiSendContract(): MultiSendContract {
     return this.#multiSendContract
-  }
-
-  private async getSafeContract({
-    ethAdapter,
-    safeVersion,
-    chainId,
-    safeAddress,
-    isL1SafeMasterCopy,
-    customContracts
-  }: GetSafeContractInstanceProps): Promise<GnosisSafeContract> {
-    const singletonDeployment = getSafeContractDeployment(
-      safeVersion,
-      chainId,
-      isL1SafeMasterCopy
-    )
-    const gnosisSafeContract = ethAdapter.getSafeContract({
-      safeVersion,
-      chainId,
-      singletonDeployment,
-      customContractAddress: safeAddress,
-      customContractAbi: customContracts?.safeMasterCopyAbi
-    })
-    const isContractDeployed = await ethAdapter.isContractDeployed(
-      gnosisSafeContract.getAddress()
-    )
-    if (!isContractDeployed) {
-      throw new Error('Safe Proxy contract is not deployed in the current network')
-    }
-    return gnosisSafeContract
-  }
-
-  private async getMultiSendContract({
-    ethAdapter,
-    safeVersion,
-    chainId,
-    customContracts
-  }: GetMultiSendContractInstanceProps): Promise<MultiSendContract> {
-    const multiSendDeployment = getMultiSendContractDeployment(safeVersion, chainId)
-    const multiSendContract = await ethAdapter.getMultiSendContract({
-      safeVersion,
-      chainId,
-      singletonDeployment: multiSendDeployment,
-      customContractAddress: customContracts?.multiSendAddress,
-      customContractAbi: customContracts?.multiSendAbi
-    })
-    const isContractDeployed = await ethAdapter.isContractDeployed(multiSendContract.getAddress())
-    if (!isContractDeployed) {
-      throw new Error('Multi Send contract is not deployed in the current network')
-    }
-    return multiSendContract
   }
 }
 

--- a/packages/safe-core-sdk/src/safeFactory/index.ts
+++ b/packages/safe-core-sdk/src/safeFactory/index.ts
@@ -200,15 +200,15 @@ class SafeFactory {
     isL1SafeMasterCopy,
     customContracts
   }: GetSafeContractInstanceProps): Promise<GnosisSafeContract> {
-    const safeSingletonDeployment = getSafeContractDeployment(
-      SAFE_LAST_VERSION,
+    const singletonDeployment = getSafeContractDeployment(
+      safeVersion,
       chainId,
       isL1SafeMasterCopy
     )
     const gnosisSafeContract = ethAdapter.getSafeContract({
-      safeVersion: safeVersion,
+      safeVersion,
       chainId,
-      singletonDeployment: safeSingletonDeployment,
+      singletonDeployment,
       customContractAddress: customContracts?.safeMasterCopyAddress,
       customContractAbi: customContracts?.safeMasterCopyAbi
     })
@@ -229,7 +229,7 @@ class SafeFactory {
   }: GetProxyFactoryContractInstanceProps): Promise<GnosisSafeProxyFactoryContract> {
     const proxyFactoryDeployment = getSafeProxyFactoryContractDeployment(safeVersion, chainId)
     const safeProxyFactoryContract = await ethAdapter.getSafeProxyFactoryContract({
-      safeVersion: safeVersion,
+      safeVersion,
       chainId,
       singletonDeployment: proxyFactoryDeployment,
       customContractAddress: customContracts?.safeProxyFactoryAddress,

--- a/packages/safe-core-sdk/src/safeFactory/index.ts
+++ b/packages/safe-core-sdk/src/safeFactory/index.ts
@@ -164,7 +164,7 @@ class SafeFactory {
     })
     const isContractDeployed = await this.#ethAdapter.isContractDeployed(safeAddress)
     if (!isContractDeployed) {
-      throw new Error('Safe Proxy contract is not deployed in the current network')
+      throw new Error('Safe Proxy contract is not deployed on the current network')
     }
     const safe = await Safe.create({
       ethAdapter: this.#ethAdapter,

--- a/packages/safe-core-sdk/src/safeFactory/index.ts
+++ b/packages/safe-core-sdk/src/safeFactory/index.ts
@@ -6,12 +6,9 @@ import {
   TransactionOptions
 } from '@gnosis.pm/safe-core-sdk-types'
 import { SAFE_LAST_VERSION } from '../contracts/config'
-import {
-  getSafeContractDeployment,
-  getSafeProxyFactoryContractDeployment
-} from '../contracts/safeDeploymentContracts'
+import { getProxyFactoryContract, getSafeContract } from '../contracts/safeDeploymentContracts'
 import Safe from '../Safe'
-import { ContractNetworkConfig, ContractNetworksConfig } from '../types'
+import { ContractNetworksConfig } from '../types'
 import { EMPTY_DATA, ZERO_ADDRESS } from '../utils/constants'
 import { validateSafeAccountConfig } from './utils'
 
@@ -58,21 +55,6 @@ interface SafeFactoryInitConfig {
   contractNetworks?: ContractNetworksConfig
 }
 
-interface GetSafeContractInstanceProps {
-  ethAdapter: EthAdapter
-  safeVersion: SafeVersion
-  chainId: number
-  isL1SafeMasterCopy?: boolean
-  customContracts?: ContractNetworkConfig
-}
-
-interface GetProxyFactoryContractInstanceProps {
-  ethAdapter: EthAdapter
-  safeVersion: SafeVersion
-  chainId: number
-  customContracts?: ContractNetworkConfig
-}
-
 class SafeFactory {
   #contractNetworks?: ContractNetworksConfig
   #isL1SafeMasterCopy?: boolean
@@ -104,13 +86,13 @@ class SafeFactory {
     this.#contractNetworks = contractNetworks
     const chainId = await this.#ethAdapter.getChainId()
     const customContracts = contractNetworks?.[chainId]
-    this.#safeProxyFactoryContract = await this.getProxyFactoryContract({
+    this.#safeProxyFactoryContract = await getProxyFactoryContract({
       ethAdapter,
       safeVersion,
       chainId,
       customContracts
     })
-    this.#gnosisSafeContract = await this.getSafeContract({
+    this.#gnosisSafeContract = await getSafeContract({
       ethAdapter,
       safeVersion,
       chainId,
@@ -191,57 +173,6 @@ class SafeFactory {
       contractNetworks: this.#contractNetworks
     })
     return safe
-  }
-
-  private async getSafeContract({
-    ethAdapter,
-    safeVersion,
-    chainId,
-    isL1SafeMasterCopy,
-    customContracts
-  }: GetSafeContractInstanceProps): Promise<GnosisSafeContract> {
-    const singletonDeployment = getSafeContractDeployment(
-      safeVersion,
-      chainId,
-      isL1SafeMasterCopy
-    )
-    const gnosisSafeContract = ethAdapter.getSafeContract({
-      safeVersion,
-      chainId,
-      singletonDeployment,
-      customContractAddress: customContracts?.safeMasterCopyAddress,
-      customContractAbi: customContracts?.safeMasterCopyAbi
-    })
-    const isContractDeployed = await this.#ethAdapter.isContractDeployed(
-      gnosisSafeContract.getAddress()
-    )
-    if (!isContractDeployed) {
-      throw new Error('Safe Proxy contract is not deployed in the current network')
-    }
-    return gnosisSafeContract
-  }
-
-  private async getProxyFactoryContract({
-    ethAdapter,
-    safeVersion,
-    chainId,
-    customContracts
-  }: GetProxyFactoryContractInstanceProps): Promise<GnosisSafeProxyFactoryContract> {
-    const proxyFactoryDeployment = getSafeProxyFactoryContractDeployment(safeVersion, chainId)
-    const safeProxyFactoryContract = await ethAdapter.getSafeProxyFactoryContract({
-      safeVersion,
-      chainId,
-      singletonDeployment: proxyFactoryDeployment,
-      customContractAddress: customContracts?.safeProxyFactoryAddress,
-      customContractAbi: customContracts?.safeProxyFactoryAbi
-    })
-    const isContractDeployed = await this.#ethAdapter.isContractDeployed(
-      safeProxyFactoryContract.getAddress()
-    )
-    if (!isContractDeployed) {
-      throw new Error('Safe Proxy Factory contract is not deployed in the current network')
-    }
-    return safeProxyFactoryContract
   }
 }
 

--- a/packages/safe-core-sdk/tests/contractManager.test.ts
+++ b/packages/safe-core-sdk/tests/contractManager.test.ts
@@ -48,7 +48,7 @@ describe('Safe contracts manager', () => {
         )
     })
 
-    it('should fail if Safe Proxy contract is not deployed in the current network', async () => {
+    it('should fail if Safe Proxy contract is not deployed on the current network', async () => {
       const { accounts, contractNetworks } = await setupTests()
       const [account1] = accounts
       const ethAdapter = await getEthAdapter(account1.signer)
@@ -60,7 +60,7 @@ describe('Safe contracts manager', () => {
             contractNetworks
           })
         )
-        .to.be.rejectedWith('Safe Proxy contract is not deployed in the current network')
+        .to.be.rejectedWith('Safe Proxy contract is not deployed on the current network')
     })
 
     it('should fail if MultiSend contract is specified in contractNetworks but not deployed', async () => {
@@ -85,10 +85,10 @@ describe('Safe contracts manager', () => {
             contractNetworks: customContractNetworks
           })
         )
-        .to.be.rejectedWith('Multi Send contract is not deployed in the current network')
+        .to.be.rejectedWith('Multi Send contract is not deployed on the current network')
     })
 
-    it('should set the MultiSend contract available in the current network', async () => {
+    it('should set the MultiSend contract available on the current network', async () => {
       const { safe, accounts, chainId, contractNetworks } = await setupTests()
       const [account1] = accounts
       const ethAdapter = await getEthAdapter(account1.signer)

--- a/packages/safe-core-sdk/tests/safeFactory.test.ts
+++ b/packages/safe-core-sdk/tests/safeFactory.test.ts
@@ -58,7 +58,7 @@ describe('Safe Proxy Factory', () => {
       }
       chai
         .expect(SafeFactory.create({ ethAdapter, contractNetworks }))
-        .rejectedWith('Safe Proxy Factory contract is not deployed in the current network')
+        .rejectedWith('Safe Proxy Factory contract is not deployed on the current network')
     })
 
     it('should instantiate the Safe Proxy Factory', async () => {


### PR DESCRIPTION
## What it solves
Resolves #165 

## How this PR fixes it:
- In the `SafeFactory` class, inside the method `getContract` was a call to the method `getSafeContractDeployment` where the safeVersion was set to the last current version. This was wrong.

- Refactor the methods that return the instances of the Safe contracts:
  - The methods `getProxyFactoryContract`, `getMultiSendContract` and `getSafeContract` were extracted to a different file.
  - There were two different implementations of `getSafeContract` before (one with `customSafeAddress` as a prop and other without it). These two were also merged in one.
