### PR TITLE
Update safe-deployments v1.9.0

### DIFF
--- a/packages/safe-core-sdk-types/package.json
+++ b/packages/safe-core-sdk-types/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "@ethersproject/bignumber": "^5.5.0",
     "@ethersproject/contracts": "^5.5.0",
-    "@gnosis.pm/safe-deployments": "^1.8.0",
+    "@gnosis.pm/safe-deployments": "^1.9.0",
     "web3-core": "^1.7.0"
   }
 }

--- a/packages/safe-core-sdk/package.json
+++ b/packages/safe-core-sdk/package.json
@@ -89,7 +89,7 @@
   "dependencies": {
     "@ethersproject/solidity": "^5.5.0",
     "@gnosis.pm/safe-core-sdk-types": "^1.0.0",
-    "@gnosis.pm/safe-deployments": "^1.8.0",
+    "@gnosis.pm/safe-deployments": "^1.9.0",
     "ethereumjs-util": "^7.1.3",
     "semver": "^7.3.5",
     "web3-utils": "^1.7.0"

--- a/packages/safe-ethers-adapters/package.json
+++ b/packages/safe-ethers-adapters/package.json
@@ -80,7 +80,7 @@
   "dependencies": {
     "@gnosis.pm/safe-core-sdk": "^2.0.0",
     "@gnosis.pm/safe-core-sdk-types": "^1.0.0",
-    "@gnosis.pm/safe-deployments": "^1.8.0",
+    "@gnosis.pm/safe-deployments": "^1.9.0",
     "axios": "^0.25.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -841,10 +841,10 @@
   resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-contracts/-/safe-contracts-1.3.0.tgz#316741a7690d8751a1f701538cfc9ec80866eedc"
   integrity sha512-1p+1HwGvxGUVzVkFjNzglwHrLNA67U/axP0Ct85FzzH8yhGJb4t9jDjPYocVMzLorDoWAfKicGy1akPY9jXRVw==
 
-"@gnosis.pm/safe-deployments@^1.8.0":
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-deployments/-/safe-deployments-1.8.0.tgz#856c15517274f924539ea4df40fffe6f009249a7"
-  integrity sha512-xK2ZZXxCEGOw+6UZAeUmvqE/4C/XTpYmv1a8KzKUgSOxcGkHsIDqcjdKjqif7gOdnwHl4+XXJUtDQEuSLT4Scg==
+"@gnosis.pm/safe-deployments@^1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-deployments/-/safe-deployments-1.9.0.tgz#0fbe8ba10001b6b9c31abb603be8cb2cdbd78c06"
+  integrity sha512-PsBGlZDb2ZEm6DJEZMlezJ0C96rOo2+cyIwYM6LHzDZbq9qjN8y1L6b+B8f1nPbzRA7ebitA74xJpqjsMBKNwg==
 
 "@graphql-tools/batch-execute@^8.3.1":
   version "8.3.1"


### PR DESCRIPTION
## What it solves
Update `safe-deployments` to v1.9.0
