### PR TITLE
Add a callback to Safe deployment

### DIFF
--- a/packages/safe-core-sdk-types/src/contracts/GnosisSafeProxyFactoryContract.ts
+++ b/packages/safe-core-sdk-types/src/contracts/GnosisSafeProxyFactoryContract.ts
@@ -5,6 +5,7 @@ export interface CreateProxyProps {
   initializer: string
   saltNonce: number
   options?: TransactionOptions
+  callback?: (txHash: string) => void
 }
 
 export interface GnosisSafeProxyFactoryContract {

--- a/packages/safe-core-sdk/src/safeFactory/index.ts
+++ b/packages/safe-core-sdk/src/safeFactory/index.ts
@@ -31,6 +31,7 @@ export interface DeploySafeProps {
   safeAccountConfig: SafeAccountConfig
   safeDeploymentConfig?: SafeDeploymentConfig
   options?: TransactionOptions
+  callback?: (txHash: string) => void
 }
 
 export interface SafeFactoryConfig {
@@ -142,7 +143,8 @@ class SafeFactory {
   async deploySafe({
     safeAccountConfig,
     safeDeploymentConfig,
-    options
+    options,
+    callback
   }: DeploySafeProps): Promise<Safe> {
     validateSafeAccountConfig(safeAccountConfig)
     const signerAddress = await this.#ethAdapter.getSignerAddress()
@@ -160,7 +162,8 @@ class SafeFactory {
       options: {
         from: signerAddress,
         ...options
-      }
+      },
+      callback
     })
     const isContractDeployed = await this.#ethAdapter.isContractDeployed(safeAddress)
     if (!isContractDeployed) {

--- a/packages/safe-core-sdk/tests/safeFactory.test.ts
+++ b/packages/safe-core-sdk/tests/safeFactory.test.ts
@@ -198,6 +198,30 @@ describe('Safe Proxy Factory', () => {
       chai.expect(deployedSafeThreshold).to.be.eq(threshold)
     })
 
+    it('should deploy a new Safe with callback', async () => {
+      const { accounts, contractNetworks } = await setupTests()
+      const [account1, account2] = accounts
+      let callbackResult = ''
+      const callback = (txHash: string) => {
+        callbackResult = txHash
+      }
+      const ethAdapter = await getEthAdapter(account1.signer)
+      const safeFactory = await SafeFactory.create({
+        ethAdapter,
+        safeVersion: safeVersionDeployed,
+        contractNetworks
+      })
+      const owners = [account1.address, account2.address]
+      const threshold = 2
+      const safeAccountConfig: SafeAccountConfig = { owners, threshold }
+      const deploySafeProps: DeploySafeProps = { safeAccountConfig, callback }
+      chai.expect(callbackResult).to.be.empty
+      const safe = await safeFactory.deploySafe(deploySafeProps)
+      chai.expect(callbackResult).to.be.not.empty
+      const safeInstanceVersion = await safe.getContractVersion()
+      chai.expect(safeInstanceVersion).to.be.eq(safeVersionDeployed)
+    })
+
     itif(safeVersionDeployed === SAFE_LAST_VERSION)(
       'should deploy last Safe version by default',
       async () => {

--- a/packages/safe-ethers-lib/src/contracts/GnosisSafe/GnosisSafeContractEthers.ts
+++ b/packages/safe-ethers-lib/src/contracts/GnosisSafe/GnosisSafeContractEthers.ts
@@ -1,7 +1,5 @@
 import { BigNumber } from '@ethersproject/bignumber'
-import { ContractTransaction } from '@ethersproject/contracts'
 import {
-  BaseTransactionResult,
   GnosisSafeContract,
   SafeTransaction,
   SafeTransactionData,
@@ -13,23 +11,8 @@ import {
   GnosisSafe as GnosisSafe_V1_3_0,
   GnosisSafeInterface
 } from '../../../typechain/src/ethers-v5/v1.3.0/GnosisSafe'
-import { EthersTransactionOptions } from '../../types'
-
-export interface EthersTransactionResult extends BaseTransactionResult {
-  transactionResponse: ContractTransaction
-  options?: EthersTransactionOptions
-}
-
-function toTxResult(
-  transactionResponse: ContractTransaction,
-  options?: EthersTransactionOptions
-): EthersTransactionResult {
-  return {
-    hash: transactionResponse.hash,
-    options,
-    transactionResponse
-  }
-}
+import { EthersTransactionOptions, EthersTransactionResult } from '../../types'
+import { toTxResult } from '../../utils'
 
 abstract class GnosisSafeContractEthers implements GnosisSafeContract {
   constructor(public contract: GnosisSafe_V1_1_1 | GnosisSafe_V1_2_0 | GnosisSafe_V1_3_0) {}

--- a/packages/safe-ethers-lib/src/index.ts
+++ b/packages/safe-ethers-lib/src/index.ts
@@ -1,7 +1,6 @@
-import { EthersTransactionResult } from './contracts/GnosisSafe/GnosisSafeContractEthers'
 import { CreateProxyProps } from './contracts/GnosisSafeProxyFactory/GnosisSafeProxyFactoryEthersContract'
 import EthersAdapter, { EthersAdapterConfig } from './EthersAdapter'
-import { EthersTransactionOptions } from './types'
+import { EthersTransactionOptions, EthersTransactionResult } from './types'
 
 export default EthersAdapter
 export { EthersAdapterConfig, EthersTransactionOptions, EthersTransactionResult, CreateProxyProps }

--- a/packages/safe-ethers-lib/src/types.ts
+++ b/packages/safe-ethers-lib/src/types.ts
@@ -1,5 +1,13 @@
+import { ContractTransaction } from '@ethersproject/contracts'
+import { BaseTransactionResult } from '@gnosis.pm/safe-core-sdk-types'
+
 export interface EthersTransactionOptions {
   from?: string
   gasLimit?: number | string
   gasPrice?: number | string
+}
+
+export interface EthersTransactionResult extends BaseTransactionResult {
+  transactionResponse: ContractTransaction
+  options?: EthersTransactionOptions
 }

--- a/packages/safe-ethers-lib/src/utils/index.ts
+++ b/packages/safe-ethers-lib/src/utils/index.ts
@@ -1,3 +1,17 @@
+import { ContractTransaction } from '@ethersproject/contracts'
+import { EthersTransactionOptions, EthersTransactionResult } from '../types'
+
 export function sameString(str1: string, str2: string): boolean {
   return str1.toLowerCase() === str2.toLowerCase()
+}
+
+export function toTxResult(
+  transactionResponse: ContractTransaction,
+  options?: EthersTransactionOptions
+): EthersTransactionResult {
+  return {
+    hash: transactionResponse.hash,
+    options,
+    transactionResponse
+  }
 }

--- a/packages/safe-web3-lib/src/contracts/GnosisSafe/GnosisSafeContractWeb3.ts
+++ b/packages/safe-web3-lib/src/contracts/GnosisSafe/GnosisSafeContractWeb3.ts
@@ -1,32 +1,15 @@
 import { BigNumber } from '@ethersproject/bignumber'
 import {
-  BaseTransactionResult,
   GnosisSafeContract,
   SafeTransaction,
   SafeTransactionData,
   SafeVersion
 } from '@gnosis.pm/safe-core-sdk-types'
-import { PromiEvent, TransactionReceipt } from 'web3-core/types'
 import { GnosisSafe as GnosisSafe_V1_1_1 } from '../../../typechain/src/web3-v1/v1.1.1/gnosis_safe'
 import { GnosisSafe as GnosisSafe_V1_2_0 } from '../../../typechain/src/web3-v1/v1.2.0/gnosis_safe'
 import { GnosisSafe as GnosisSafe_V1_3_0 } from '../../../typechain/src/web3-v1/v1.3.0/gnosis_safe'
-import { Web3TransactionOptions } from '../../types'
-
-export interface Web3TransactionResult extends BaseTransactionResult {
-  promiEvent: PromiEvent<TransactionReceipt>
-  options?: Web3TransactionOptions
-}
-
-function toTxResult(
-  promiEvent: PromiEvent<TransactionReceipt>,
-  options?: Web3TransactionOptions
-): Promise<Web3TransactionResult> {
-  return new Promise((resolve, reject) =>
-    promiEvent
-      .once('transactionHash', (hash: string) => resolve({ hash, promiEvent, options }))
-      .catch(reject)
-  )
-}
+import { Web3TransactionOptions, Web3TransactionResult } from '../../types'
+import { toTxResult } from '../../utils'
 
 abstract class GnosisSafeContractWeb3 implements GnosisSafeContract {
   constructor(public contract: GnosisSafe_V1_1_1 | GnosisSafe_V1_2_0 | GnosisSafe_V1_3_0) {}

--- a/packages/safe-web3-lib/src/index.ts
+++ b/packages/safe-web3-lib/src/index.ts
@@ -1,6 +1,5 @@
-import { Web3TransactionResult } from './contracts/GnosisSafe/GnosisSafeContractWeb3'
 import { CreateProxyProps } from './contracts/GnosisSafeProxyFactory/GnosisSafeProxyFactoryWeb3Contract'
-import { Web3TransactionOptions } from './types'
+import { Web3TransactionOptions, Web3TransactionResult } from './types'
 import Web3Adapter, { Web3AdapterConfig } from './Web3Adapter'
 
 export default Web3Adapter

--- a/packages/safe-web3-lib/src/types.ts
+++ b/packages/safe-web3-lib/src/types.ts
@@ -1,5 +1,13 @@
+import { BaseTransactionResult } from '@gnosis.pm/safe-core-sdk-types'
+import { PromiEvent, TransactionReceipt } from 'web3-core/types'
+
 export interface Web3TransactionOptions {
   from?: string
   gas?: number | string
   gasPrice?: number | string
+}
+
+export interface Web3TransactionResult extends BaseTransactionResult {
+  promiEvent: PromiEvent<TransactionReceipt>
+  options?: Web3TransactionOptions
 }

--- a/packages/safe-web3-lib/src/utils/index.ts
+++ b/packages/safe-web3-lib/src/utils/index.ts
@@ -1,3 +1,17 @@
+import { PromiEvent, TransactionReceipt } from 'web3-core/types'
+import { Web3TransactionOptions, Web3TransactionResult } from '../types'
+
 export function sameString(str1: string, str2: string): boolean {
   return str1.toLowerCase() === str2.toLowerCase()
+}
+
+export async function toTxResult(
+  promiEvent: PromiEvent<TransactionReceipt>,
+  options?: Web3TransactionOptions
+): Promise<Web3TransactionResult> {
+  return new Promise((resolve, reject) =>
+    promiEvent
+      .once('transactionHash', (hash: string) => resolve({ hash, promiEvent, options }))
+      .catch(reject)
+  )
 }


### PR DESCRIPTION
## What it solves
Adds a callback to the `deploySafe` method in the `SafeFactory` class.

This callback receives as a parameter the `tcxHash` of the deployment transaction, allowing to track the transaction outside of the SDK, in parallel, meanwhile the deployment is being executed.

```js
const callback = (txHash: string): void => {
  console.log({ txHash })
}

const safeFactory = await SafeFactory.create({ ethAdapter })

const deploySafeProps: DeploySafeProps = { safeAccountConfig, callback }
const safe = await safeFactory.deploySafe(deploySafeProps)
```